### PR TITLE
New footer copyright text

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -1,8 +1,8 @@
 @import  "../../themes/longhorn-theme/assets/sass/main";
 
 :root {
-    --primary-color   : #5F224A;
-    --secondary-color : #EA3A3A;
-    --dark            : #33313b;
-    --light           : #F3F3F3;
-  }
+  --primary-color   : #5F224A;
+  --secondary-color : #EA3A3A;
+  --dark            : #33313b;
+  --light           : #F3F3F3;
+}

--- a/themes/longhorn-theme/assets/sass/main.scss
+++ b/themes/longhorn-theme/assets/sass/main.scss
@@ -98,9 +98,8 @@ a {
 }
 
 // /* header and footer areas */
-.rancher-header, 
-.sub-header, 
-footer {
+.rancher-header,
+.sub-header {
   padding: 1rem;
   display: flex;
   justify-content: space-between;
@@ -121,7 +120,7 @@ footer {
 
 .sub-header {
   background: white;
-  
+
   a img {
     height: 40px;
   }
@@ -133,13 +132,13 @@ footer {
     align-items: center;
     flex-direction: row;
 
-  
+
     li {
       display: inline-block;
       padding: 0;
       margin: 0;
       border: none;
-  
+
       &:last-child {
         padding-right: 0;
       }
@@ -641,7 +640,7 @@ section {
   }
   .grid-dynamic {
     display: block;
-    
+
     h5 {
       text-align: left;
       border-bottom: solid thin var(--light);

--- a/themes/longhorn-theme/layouts/partials/footer.html
+++ b/themes/longhorn-theme/layouts/partials/footer.html
@@ -1,6 +1,12 @@
+{{ $firstYear   := "2019" | int }}
+{{ $currentYear := now.Year }}
+{{ $yearString  := cond (eq $firstYear $currentYear) $firstYear (printf "%s-%s" $firstYear $currentYear) }}
 <footer>
-  <div>
-    <p><small>&copy; <a href="/">Longhorn</a> Authors {{ now.Year }} · Documentation Distributed under CC-BY-4.0</small></p>
-    <p><small>&copy; 2019 The Linux Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" target="blank">Trademark Usage</a> page.</small></p>
-  </div>
+  <p>
+    &copy; {{ $yearString }} Longhorn Authors | Documentation Distributed under CC-BY-4.0
+  </p>
+
+  <p>
+    &copy; {{ $currentYear }} The Linux Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage/" target="_blank">Trademark Usage</a> page.
+  </p>
 </footer>


### PR DESCRIPTION
This PR changes the copyright text in the footer to bring Longhorn more in line with other CNCF projects. I see that this was updated in #13 but I think the approach in this PR is a bit more automated.