### PR TITLE
Add explanation on how to use a self signed ssl certificate for s3

### DIFF
--- a/content/docs/0.8.1/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/0.8.1/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -102,7 +102,8 @@ We provides two testing purpose backupstore based on NFS server and Minio S3 ser
     data:
       AWS_ACCESS_KEY_ID: bG9uZ2hvcm4tdGVzdC1hY2Nlc3Mta2V5 # longhorn-test-access-key
       AWS_SECRET_ACCESS_KEY: bG9uZ2hvcm4tdGVzdC1zZWNyZXQta2V5 # longhorn-test-secret-key
-      AWS_ENDPOINTS: aHR0cDovL21pbmlvLXNlcnZpY2UuZGVmYXVsdDo5MDAw # http://minio-service.default:9000
+      AWS_ENDPOINTS: aHR0cHM6Ly9taW5pby1zZXJ2aWNlLmRlZmF1bHQ6OTAwMA== # https://minio-service.default:9000
+      AWS_CERT: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREekNDQWZlZ0F3SUJBZ0lSQU91d1oybTZ6SXl3c1h2a2UyNS9LYzB3RFFZSktvWklodmNOQVFFTEJRQXcKRWpFUU1BNEdBMVVFQ2hNSFFXTnRaU0JEYnpBZUZ3MHlNREEwTWpVd01qRTJNalphRncweU1UQTBNalV3TWpFMgpNalphTUJJeEVEQU9CZ05WQkFvVEIwRmpiV1VnUTI4d2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3CmdnRUtBb0lCQVFEWkpyWVUraVJhc1huSExvb1d0Tm9OQWpxN0U3YWNlQTJQZnQ1ZFM3aExzVUtCbExMOVVQMmUKZ0QrVFl3RmtCWVJNU3BsV0tNT0tuWEErNDZSVkRwSkhwSTF4YjhHNDV0L3gzVXhVaWc2WUFVbDBnTFV6N01rMQpYSUtRaWZZUllaL0FjUzJqU0VOYjRISFJ1aFZ5NzV0ZDdCaXNhd2J2TTJwTXI0dWNSR1lwZ3J6Z2V2eFBXSHZ1CnkxT29yRnIvNjFwV28wcG9aSXhtRmM2YXMzekw0NWlrRzRHN1A2ejJPamc4NGdrdnR4RFUzYVdmWXRNb3VhL3gKQVhkRlRCd2NqMkNHMHJtdmd4cE5KeEx5Kzl5NDVLVGU1SFlSd0xxUjVCeWtnVGt2RGplcWdXTnJyQWdCL3lLTApwU1ZjRmZkKzBWNjhyQmtNMEt3VlQ3bXF2WWRsZDVrTkFnTUJBQUdqWURCZU1BNEdBMVVkRHdFQi93UUVBd0lDCnBEQVRCZ05WSFNVRUREQUtCZ2dyQmdFRkJRY0RBVEFQQmdOVkhSTUJBZjhFQlRBREFRSC9NQ1lHQTFVZEVRUWYKTUIyQ0ZXMXBibWx2TFhObGNuWnBZMlV1WkdWbVlYVnNkSWNFZndBQUFUQU5CZ2txaGtpRzl3MEJBUXNGQUFPQwpBUUVBdDBQYjM5QWliS0EyU1BPTHJHSmVRVlNaVTdZbFUyU0h0M2lhcFVBS1Rtb2o1RTQrTU8yV2NnbktoRktrCnNxeW9CYjBPYTNPMHdXUnRvVnhNUGdPQS9FaXNtZExQWmJIVTUzS2w3SDVWMm8rb0tQY0YydTk2ajdlcUZxSkUKMlltQkpBTHlUVks5LzZhS1hOSnRYZE5xRmpPMWJRcDJRTURXbjQyZGgyNjJLZmgvekM4enRyK0h4RzhuTVpQQwpsZUpxbzU3S0tkZ0YvZHVBWTdUaUI2cThTelE4RmViMklQQ2FhdVVLNzdBZ0d5b3kzK1JuWkdZV2U1MG1KVnN6CmdkQTFURmg0TVdMeUxWSFdIbnl2cEFvTjJIUjQrdzhYRkpJS2VRRFM1YklJM1pFeU5OQUZNRDg0bTVReGY4cjUKMEovQWhXTVVyMFUwcCtiRi9KM3FDQVNSK3c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
     ```
     For more information on creating a secret, see [the Kubernetes documentation.](https://kubernetes.io/docs/concepts/configuration/secret/#creating-a-secret-manually) The secret must be created in the `longhorn-system` namespace for Longhorn to access it.
 
@@ -111,6 +112,11 @@ We provides two testing purpose backupstore based on NFS server and Minio S3 ser
 3. Click the **Backup** tab in the UI. It should report an empty list without any errors.
 
 **Result:** Longhorn can store backups in S3. To create a backup, see [this section.](../create-a-backup)
+
+### Using a self-signed SSL certificate for S3 communication
+If you want to use a self-signed SSL certificate, you can specify AWS_CERT in the Kubernetes secret you provided to Longhorn. See the example in [Set up a Local Testing Backupstore](#set-up-a-local-testing-backupstore).
+It's important to note that the certificate needs to be in PEM format, and must be its own CA. Or one must include a certificate chain that contains the CA certificate.
+To include multiple certificates, one can just concatenate the different certificates (PEM files).
 
 ### NFS Backupstore
 
@@ -122,6 +128,6 @@ The target URL should look like this:
 nfs://longhorn-test-nfs-svc.default:/opt/backupstore
 ```
 
-You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/master/deploy/backupstores/nfs-backupstore.yaml). 
+You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/master/deploy/backupstores/nfs-backupstore.yaml).
 
-**Result:** Longhorn can store backups in S3. To create a backup, see [this section.](../create-a-backup)
+**Result:** Longhorn can store backups in NFS. To create a backup, see [this section.](../create-a-backup)


### PR DESCRIPTION
Our default minio-test backupstore is setup to use such a certificate
and can be used as an example.

Signed-off-by: Joshua Moody <joshua.moody@rancher.com>
