### PR TITLE
Remove non-functioning redirects

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -3,8 +3,7 @@
 /docs     /docs/{{ $latest }}     200!
 /docs/latest     /docs/{{ $latest }}
 /docs/latest/*     /docs/{{ $latest }}/:splat
-https://docs.longhorn.io/    https://longhorn.io/docs/{{ $latest }}
-https://docs.longhorn.io/*    https://longhorn.io/docs/{{ $latest }}/:splat 200
+
 {{- range $docs -}}
 {{- $version := index (split .File.Path "/") 1 }}
 {{ .RelPermalink | replaceRE (printf "/%s" $version) "" }}     {{ .RelPermalink }}


### PR DESCRIPTION
This PR removes subdomain redirects that cannot be applied by the Netlify platform.