### PR TITLE
Update longhorn-manager.md

### DIFF
--- a/content/docs/0.8.1/deploy/upgrade/longhorn-manager.md
+++ b/content/docs/0.8.1/deploy/upgrade/longhorn-manager.md
@@ -82,6 +82,21 @@ If the migration fails and the error log mentioned above is printed out, users n
 
 3. Use the Longhorn UI to recreate the PV and PVC.
 
+4. Due to removing the compatible csi deployment, there might be the following error message in kubelet logs:
+    ```
+    clientconn.go:1120] grpc: addrConn.createTransport failed to connect to {/var/lib/kubelet/plugins/io.rancher.longhorn-reg.sock 0  <nil>}. Err :connection error: desc = "transport: Error while dialing dial unix /var/lib/kubelet/plugins/io.rancher.longhorn-reg.sock: connect: connection refused". Reconnecting...
+    ```
+    And it can be fixed by removing the `io.rancher.longhorn-reg.sock` from the kubelet on the node with the following command:
+
+    > **Note**: Please make sure there is no PV running with driver `io.rancher.longhorn`.
+    ```
+    rm /var/lib/kubelet/plugins_registry/io.rancher.longhorn-reg.sock
+    ```
+    Meanwhile kubelet will log the following message:
+    ```
+    plugin_watcher.go:212] Removing socket path /var/lib/kubelet/plugins_registry/io.rancher.longhorn-reg.sock from desired state cache
+    ```
+
 ### Upgrading Longhorn Manager from v0.6.2 to v0.7.0
 
 You will need to follow this guide to upgrade the Longhorn manager from v0.6.2 to v0.7.0.
@@ -224,5 +239,4 @@ Steps to roll back:
     ```
     docker restart kubelet
     ```
-
-3. Rollback: Use `kubectl apply` or the Rancher catalog app to roll back Longhorn.
+4. Rollback: Use `kubectl apply` or the Rancher catalog app to roll back Longhorn.


### PR DESCRIPTION
This commit is to add one addition migration failure fix for removing
compitable csi deployment from v0.6.2 or older version to v0.8.1.

https://github.com/longhorn/longhorn/issues/1412

Signed-off-by: Bo Tao <bo.tao@rancher.com>