### PR TITLE
Note a subpath may be used, with an example.

### DIFF
--- a/content/docs/1.0.0/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/1.0.0/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -58,7 +58,11 @@ This page covers the following topics:
     s3://<your-bucket-name>@<your-aws-region>/
     ```
 
-    Make sure that you have `/` at the end, otherwise you will get an error.
+    Make sure that you have `/` at the end, otherwise you will get an error. A subdirectory (prefix) may be used:
+    
+    ```text
+    s3://<your-bucket-name>@<your-aws-region>/mypath/
+    ```
 
    Also make sure you've set **`<your-aws-region>` in the URL**. For example, for Google Cloud Storage, you can find the region code [here.](https://cloud.google.com/storage/docs/locations)
 


### PR DESCRIPTION
..it works on 0.8, at least. I thought it might fail, so perhaps this will save some effort for others.

I haven't built the docs, I'm just assuming the format will be fine.