### PR TITLE
Add documentation for Priority Class setting

### DIFF
--- a/content/docs/1.0.0/advanced-resources/deploy/priority-class.md
+++ b/content/docs/1.0.0/advanced-resources/deploy/priority-class.md
@@ -1,0 +1,38 @@
+---
+title: Priority Class
+weight: 3
+---
+The Priority Class setting can be used to set a higher priority on Longhorn workloads in the cluster, preventing them from being the first to be evicted during node pressure situations.
+
+For more information on how pod priority works, refer to the [official Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/).
+
+# Setting Priority Class
+
+### During Longhorn Installation
+
+Follow the instructions to set the initial Priority Class setting: [Customize Default Settings](../customizing-default-settings)
+
+> **Warning:** Longhorn will not start if Priority Class setting is invalid (such as the Priority Class not existing). You can see if this is the case by checking the status of the longhorn-manager DaemonSet with `kubectl -n longhorn-system describe daemonset.apps/longhorn-manager`. You will need to uninstall Longhorn and restart the installation if this is the case.
+
+### After Longhorn Installation
+
+The Priority Class setting can be found in the Longhorn UI:
+
+Setting -> General -> Priority Class
+
+Users can update or remove the Priority Class here, but note that this will result in recreation of all the Longhorn system components. The Priority Class setting will reject values that appear to be invalid Priority Classes.
+
+# Usage
+
+Before modifying the Priority Class setting, all Longhorn volumes must be detached.
+
+Since all Longhorn components will be restarted, the Longhorn system will temporarily be unavailable. If there are running Longhorn volumes in the system, Longhorn system will not be able to restart its components, and the request will be rejected.
+
+Don't operate the Longhorn system after modifying the Priority Class setting, as the Longhorn components will be restarting.
+
+Do not delete the Priority Class in use by Longhorn, as this can cause new Longhorn workloads to fail to come online.
+
+## History
+[Original Feature Request](https://github.com/longhorn/longhorn/issues/1487)
+
+Available since v1.0.1

--- a/content/docs/1.0.0/references/settings.md
+++ b/content/docs/1.0.0/references/settings.md
@@ -35,6 +35,7 @@ weight: 1
 - [Danger Zone](#danger-zone)
   - [Kubernetes Taint Toleration](#kubernetes-taint-toleration)
   - [Guaranteed Engine CPU](#guaranteed-engine-cpu)
+  - [Priority Class](#priority-class)
 
 ### Customizing Default Settings
 
@@ -216,3 +217,12 @@ For example, if the setting value is 0.25 or 250m, that means you must have at l
 There are normally two Instance Manager Pods per node: one for the engine processes, and another one for the replica processes. But when Longhorn is upgrading from an old version of the Instance Manager to a new version, there can be at most four Pods requesting the reserved CPU on the node.
 
 Taking other Kubernetes system components' CPU reservation request into consideration, we recommend having at least eight times the amount of CPU as the Guaranteed Engine CPU.
+
+#### Priority Class
+> Example: `high-priority`
+
+By default, Longhorn workloads run with the same priority as other pods in the cluster, meaning in cases of node pressure, such as a node running out of memory, Longhorn workloads will be at the same priority as other Pods for eviction.
+
+The Priority Class setting will specify a Priority Class for the Longhorn workloads to run as. This can be used to set the priority for Longhorn workloads higher so that they will not be the first to be evicted when a node is under pressure.
+
+> **Warning:** This setting should only be changed after detaching all Longhorn volumes, as the Longhorn components will be restarted to apply the setting. The Priority Class update will take a while, and users cannot operate Longhorn system during the update. Hence, it's recommended to set the Priority Class during Longhorn deployment.

--- a/content/docs/1.0.0/references/settings.md
+++ b/content/docs/1.0.0/references/settings.md
@@ -226,3 +226,5 @@ By default, Longhorn workloads run with the same priority as other pods in the c
 The Priority Class setting will specify a Priority Class for the Longhorn workloads to run as. This can be used to set the priority for Longhorn workloads higher so that they will not be the first to be evicted when a node is under pressure.
 
 > **Warning:** This setting should only be changed after detaching all Longhorn volumes, as the Longhorn components will be restarted to apply the setting. The Priority Class update will take a while, and users cannot operate Longhorn system during the update. Hence, it's recommended to set the Priority Class during Longhorn deployment.
+
+See [Priority Class](../../advanced-resources/deploy/priority-class) for details.

--- a/content/docs/1.0.0/references/settings.md
+++ b/content/docs/1.0.0/references/settings.md
@@ -50,7 +50,7 @@ If no other disks exist, create the default disk automatically, only on nodes wi
 
 If disabled, the default disk will be created on all new nodes when the node is detected for the first time.
 
-This option is useful if you want to scale the cluster but don't want to use storage on the new nodes, or if you want to [customize disks for Longhorn nodes](../../advanced-resources/default-disk-and-node-config). 
+This option is useful if you want to scale the cluster but don't want to use storage on the new nodes, or if you want to [customize disks for Longhorn nodes](../../advanced-resources/default-disk-and-node-config).
 
 #### Default Data Path
 > Default: `/var/lib/longhorn/`


### PR DESCRIPTION
This PR adds documentation for the `Priority Class` setting that was requested in longhorn/longhorn#1487, laying out what the setting does, how to use it during initial `Longhorn` installation, and the dangers of modifying the `Setting` (since it results in redeployment of all `Longhorn` workloads.