### PR TITLE
Update docs with Helm repo

### DIFF
--- a/content/docs/1.0.0/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/1.0.0/advanced-resources/deploy/customizing-default-settings.md
@@ -60,24 +60,26 @@ From the project view in Rancher, go to **Apps > Launch > Longhorn** and edit th
 
 ### Using Helm
 
-1. Download the chart in the Longhorn repo:
+Use the Helm command with the `--set` flag to modify the default settings. For example:
+
+```shell
+helm install longhorn/longhorn \
+--name longhorn \
+--namespace longhorn-system \
+--set defaultSettings.taintToleration="key1=value1:NoSchedule; key2:NoExecute"
+```
+
+You can also provide a copy of the `values.yaml` file with the default settings modified to the `--values` flag when running the Helm command:
+
+1. Obtain a copy of the `values.yaml` file from GitHub:
 
     ```shell
-    git clone https://github.com/longhorn/longhorn.git
+    curl -Lo values.yaml https://raw.githubusercontent.com/longhorn/charts/master/charts/longhorn/values.yaml
     ```
 
-2. Use helm command with `--set` flag to modify the default settings. For example:
+2. Modify the default settings in the YAML file. The following is an example snippet of `values.yaml`:
 
-    ```shell
-    helm install ./longhorn/chart \
-    --name longhorn \
-    --namespace longhorn-system \
-    --set defaultSettings.taintToleration="key1=value1:NoSchedule; key2:NoExecute"
-    ```
-
-    Or directly modify the default settings in the YAML file `longhorn/chart/values.yaml`, then use the Helm command without `--set` to deploy Longhorn. The following is an example `longhorn/chart/values.yaml`:
-
-    ```
+    ```yaml
     defaultSettings:
       backupTarget: s3://backupbucket@us-east-1/backupstore
       backupTargetCredentialSecret: minio-secret
@@ -100,10 +102,10 @@ From the project view in Rancher, go to **Apps > Launch > Longhorn** and edit th
       mkfsExt4Parameters: -O ^64bit,^metadata_csum
     ```
 
-    Then use the `helm` command:
+3. Run Helm with `values.yaml`:
 
-    ```
-    helm install ./longhorn/chart --name longhorn --namespace longhorn-system
+    ```shell
+    helm install longhorn/longhorn --name longhorn --namespace longhorn-system --values values.yaml
     ```
 
 For more info about using helm, see the section about

--- a/content/docs/1.0.0/deploy/install/install-with-helm.md
+++ b/content/docs/1.0.0/deploy/install/install-with-helm.md
@@ -22,27 +22,33 @@ If you're using a Helm version prior to version 3.0, you need to [install Tiller
 
 ### Installing Longhorn
 
-1. Clone the Longhorn repository:
+1. Add the Longhorn Helm repository:
 
     ```shell
-    git clone https://github.com/longhorn/longhorn && cd longhorn
+   helm repo add longhorn https://charts.longhorn.io
     ```
 
-2. Install Longhorn in the `longhorn-system` namespace.
+2. Fetch the latest charts from the repository:
+
+    ```shell
+   helm repo update
+    ```
+
+3. Install Longhorn in the `longhorn-system` namespace.
     To install Longhorn with Helm 2, use this command:
 
-    ```
-    helm install ./longhorn/chart --name longhorn --namespace longhorn-system
+    ```shell
+    helm install longhorn/longhorn --name longhorn --namespace longhorn-system
     ```
 
     To install Longhorn with Helm 3, use these commands:
 
-    ```
+    ```shell
     kubectl create namespace longhorn-system
-    helm install longhorn ./longhorn/chart/ --namespace longhorn-system
+    helm install longhorn longhorn/longhorn --namespace longhorn-system
     ```
 
-3. To confirm that the deployment succeeded, run:
+4. To confirm that the deployment succeeded, run:
 
     ```bash
     kubectl -n longhorn-system get pod


### PR DESCRIPTION
This PR updates the docs on the website to reference the new `Helm` repository at https://charts.longhorn.io. The `Helm` installation instructions have been modified to reference that repository instead of having the user clone the `Longhorn` repository to access the chart. Additionally, the instructions for modifying the `Default Settings` in `Longhorn` have been updated to omit the `git clone` step and to indicate how to obtain and modify a copy of `values.yaml` for `Helm` if using the `--values` flag.