### PR TITLE
advance-resources/deploy: update document about providing list of images and scripts to pull and push all Longhorn component images to user provided registry

### DIFF
--- a/content/docs/1.0.0/advanced-resources/deploy/airgap.md
+++ b/content/docs/1.0.0/advanced-resources/deploy/airgap.md
@@ -12,13 +12,13 @@ weight: 2
     ```shell
     wget https://raw.githubusercontent.com/longhorn/longhorn/v1.0.1/deploy/longhorn-images.txt
     ```
-  - We provide a script to quickly pull and export the above `longhorn-images.txt` list to a `tar` file: [save-images.sh](https://raw.githubusercontent.com/longhorn/longhorn/v1.0.1/scripts/save-images.sh). Example:
+  - We provide a script, [save-images.sh](https://raw.githubusercontent.com/longhorn/longhorn/v1.0.1/scripts/save-images.sh), to quickly pull the above `longhorn-images.txt` list. If you specify a `tar.gz` file name for flag `--images`, the script will save all images to the provided filename. In the example below, the script pulls and saves Longhorn images to the file `longhorn-images.tar.gz`. You then can copy the file to your air-gap environment. On the other hand, if you don't specify the file name, the script just pulls the list of images to your computer.
     ```shell
     wget https://raw.githubusercontent.com/longhorn/longhorn/v1.0.1/scripts/save-images.sh
     chmod +x save-images.sh
     ./save-images.sh --image-list longhorn-images.txt --images longhorn-images.tar.gz
     ```
-  - We provide another script to load images from the `tar` file and push them to your private registry: [load-images.sh](https://raw.githubusercontent.com/longhorn/longhorn/v1.0.1/scripts/load-images.sh). Example:
+  - We provide another script, [load-images.sh](https://raw.githubusercontent.com/longhorn/longhorn/v1.0.1/scripts/load-images.sh), to push Longhorn images to your private registry. If you specify a `tar.gz` file name for flag `--images`, the script loads images from the `tar` file and pushes them. Otherwise, it will find images in your local Docker and push them. In the example below, the script load images from the file `longhorn-images.tar.gz` and push them to `<YOUR-PRIVATE-REGISTRY>`
     ```shell
     wget https://raw.githubusercontent.com/longhorn/longhorn/v1.0.1/scripts/load-images.sh
     chmod +x load-images.sh


### PR DESCRIPTION

Give user the option to skip exporting and loading images from a tar.gz file

longhorn/longhorn#1419