### PR TITLE
Add note about root requirement to deploy docs

### DIFF
--- a/content/docs/1.0.1/deploy/install/_index.md
+++ b/content/docs/1.0.1/deploy/install/_index.md
@@ -66,6 +66,12 @@ daemonset.apps "longhorn-environment-check" deleted
 clean up complete
 ```
 
+### Pod Security Policy
+
+Starting with v1.0.2, Longhorn is shipped with a default Pod Security Policy that will give Longhorn the necessary privileges to be able to run properly.
+
+No special configuration is needed for Longhorn to work properly on clusters with Pod Security Policy enabled.
+
 ### Notes on Mount Propagation
 
 If your Kubernetes cluster was provisioned by Rancher v2.0.7+ or later, the MountPropagation feature is enabled by default.

--- a/content/docs/1.0.1/deploy/install/_index.md
+++ b/content/docs/1.0.1/deploy/install/_index.md
@@ -30,6 +30,8 @@ Each node in the Kubernetes cluster where Longhorn is installed must fulfill the
 - `curl`, `findmnt`, `grep`, `awk`, `blkid`, `lsblk` must be installed.
 - [Mount propagation](https://kubernetes-csi.github.io/docs/deploying.html#enabling-mount-propagation) must be enabled.
 
+The Longhorn workloads must be able to run as root in order for Longhorn to be deployed and operated properly.
+
 CSI v1.1 is supported.
 
 [This script](#using-the-environment-check-script) can be used to check the Longhorn environment for potential issues.


### PR DESCRIPTION
This PR adds a note to the list of requirements for deploying Longhorn indicating that Longhorn needs root access in order for Longhorn to be properly deployed and operated as requested in longhorn/longhorn#1625. Documentation about Pod Security Policy requirements has been omitted due to concerns about Pod Security Policy being deprecated in future versions of Kubernetes.