### PR TITLE
high-availability: add document for how to handle node failure

### DIFF
--- a/content/docs/1.1.0/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/1.1.0/advanced-resources/deploy/customizing-default-settings.md
@@ -54,6 +54,7 @@ From the project view in Rancher, go to **Apps > Launch > Longhorn** and edit th
         disable-scheduling-on-cordoned-node: false
         replica-zone-soft-anti-affinity: false
         volume-attachment-recovery-policy: never
+        node-down-pod-deletion-policy: do-nothing
         mkfs-ext4-parameters: -O ^64bit,^metadata_csum
     ---
     ```
@@ -99,6 +100,7 @@ You can also provide a copy of the `values.yaml` file with the default settings 
       disableSchedulingOnCordonedNode: false
       replicaZoneSoftAntiAffinity: false
       volumeAttachmentRecoveryPolicy: never
+      nodeDownPodDeletionPolicy: do-nothing
       mkfsExt4Parameters: -O ^64bit,^metadata_csum
     ```
 

--- a/content/docs/1.1.0/high-availability/node-failure.md
+++ b/content/docs/1.1.0/high-availability/node-failure.md
@@ -55,6 +55,15 @@ Which then allows the pending replacement pods to start correctly with the reque
 Longhorn will recover the Volume Attachment from a failed node as soon as there are pending replacement pods available.
 Which then allows the pending replacement pods to start correctly with the requested volumes being available.
 
+### Pod Deletion Policy When Node Downs
+
+Kubernetes never force deletes pods of StatefulSet or Deployment on a down node. Since the pod on the down node wasn't removed,
+the volume will be stuck on the down node with it as well. The replacement pods cannot be started because the Longhorn volume is
+RWO (see more about access modes [here](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) ), which can
+only be attached to one node at a time. Longhorn provides an option for users to help automatically force delete terminating pods
+of StatefulSet/Deployment on the down node. After force deleting, Kubernetes will detach Longhorn volume and spin up replacement
+pods on a new node. You can find more detail about the setting options in the `Pod Deletion Policy When Node Downs` in setting tab in Longhorn UI or [Customizing Default Settings](../../advanced-resources/deploy/customizing-default-settings/)
+
 ## What to expect when recovering a failed Kubernetes Node
 
 If the node is back online within 5 - 6 minutes of the failure, Kubernetes will restart pods, unmount, and re-mount volumes without volume re-attaching and VolumeAttachment cleanup.

--- a/content/docs/1.1.0/high-availability/node-failure.md
+++ b/content/docs/1.1.0/high-availability/node-failure.md
@@ -55,14 +55,15 @@ Which then allows the pending replacement pods to start correctly with the reque
 Longhorn will recover the Volume Attachment from a failed node as soon as there are pending replacement pods available.
 Which then allows the pending replacement pods to start correctly with the requested volumes being available.
 
-### Pod Deletion Policy When Node Downs
+### Pod Deletion Policy When Node is Down
 
-Kubernetes never force deletes pods of StatefulSet or Deployment on a down node. Since the pod on the down node wasn't removed,
-the volume will be stuck on the down node with it as well. The replacement pods cannot be started because the Longhorn volume is
+Kubernetes never force deletes pods of StatefulSet or Deployment on a node that is down. Since the pod on the node that is down isn't removed, the volume becomes stuck on that node as well. The replacement pods cannot be started because the Longhorn volume is
 RWO (see more about access modes [here](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) ), which can
-only be attached to one node at a time. Longhorn provides an option for users to help automatically force delete terminating pods
-of StatefulSet/Deployment on the down node. After force deleting, Kubernetes will detach Longhorn volume and spin up replacement
-pods on a new node. You can find more detail about the setting options in the `Pod Deletion Policy When Node Downs` in setting tab in Longhorn UI or [Customizing Default Settings](../../advanced-resources/deploy/customizing-default-settings/)
+only be attached to one node at a time.
+
+Longhorn provides an option for users to help automatically force delete terminating pods of StatefulSet/Deployment on the node that is down. After force deleting, Kubernetes will detach the Longhorn volume and spin up replacement pods on a new node.
+
+You can find more detail about the setting options in the `Pod Deletion Policy When Node is Down` in the **Settings** tab in the Longhorn UI or [Customizing Default Settings](../../advanced-resources/deploy/customizing-default-settings/)
 
 ## What to expect when recovering a failed Kubernetes Node
 

--- a/content/docs/1.1.0/references/settings.md
+++ b/content/docs/1.1.0/references/settings.md
@@ -18,7 +18,7 @@ weight: 1
   - [Automatic Salvage](#automatic-salvage)
   - [Registry Secret](#registry-secret)
   - [Volume Attachment Recovery Policy](#volume-attachment-recovery-policy)
-  - [Pod Deletion Policy When Node Downs](#pod-deletion-policy-when-node-downs)
+  - [Pod Deletion Policy When Node is Down](#pod-deletion-policy-when-node-is-down)
   - [Custom mkfs.ext4 parameters](#custom-mkfsext4-parameters)
 
 - [Backups](#backups)
@@ -119,15 +119,15 @@ Defines the Longhorn action when a Volume is stuck with a Deployment Pod on a fa
 - `never`: The default Kubernetes behavior of never deleting volume attachments on terminating pods. Longhorn will not recover the Volume Attachment from a failed node.
 - `immediate`: Longhorn will recover the Volume Attachment from the failed node as soon as there are pending replacement pods available.
 
-#### Pod Deletion Policy When Node Downs
+#### Pod Deletion Policy When Node is Down
 > Default: `do-nothing`
 
-Defines the Longhorn action when a Volume is stuck with a StatefulSet/Deployment Pod on a down node.
+Defines the Longhorn action when a Volume is stuck with a StatefulSet/Deployment Pod on a node that is down.
 
-- `do-nothing` is the default Kubernetes behavior of never force delete StatefulSet/Deployment terminating pods.
-- `delete-statefulset-pod` Longhorn will force delete StatefulSet terminating pods on down node to release Longhorn volumes so that Kubernetes can spin up replacement pods.
-- `delete-deployment-pod` Longhorn will force delete Deployment terminating pods on down node to release Longhorn volumes so that Kubernetes can spin up replacement pods.
-- `delete-both-statefulset-and-deployment-pod` Longhorn will force delete StatefulSet/Deployment terminating pods on down node to release Longhorn volumes so that Kubernetes can spin up replacement pods.
+- `do-nothing` is the default Kubernetes behavior of never force deleting StatefulSet/Deployment terminating pods. Since the pod on the node that is down isn't removed, Longhorn volumes are stuck on nodes that are down.
+- `delete-statefulset-pod` Longhorn will force delete StatefulSet terminating pods on nodes that are down to release Longhorn volumes so that Kubernetes can spin up replacement pods.
+- `delete-deployment-pod` Longhorn will force delete Deployment terminating pods on nodes that are down to release Longhorn volumes so that Kubernetes can spin up replacement pods.
+- `delete-both-statefulset-and-deployment-pod` Longhorn will force delete StatefulSet/Deployment terminating pods on nodes that are down to release Longhorn volumes so that Kubernetes can spin up replacement pods.
 
 #### Custom mkfs.ext4 parameters
 

--- a/content/docs/1.1.0/references/settings.md
+++ b/content/docs/1.1.0/references/settings.md
@@ -18,6 +18,7 @@ weight: 1
   - [Automatic Salvage](#automatic-salvage)
   - [Registry Secret](#registry-secret)
   - [Volume Attachment Recovery Policy](#volume-attachment-recovery-policy)
+  - [Pod Deletion Policy When Node Downs](#pod-deletion-policy-when-node-downs)
   - [Custom mkfs.ext4 parameters](#custom-mkfsext4-parameters)
 
 - [Backups](#backups)
@@ -117,6 +118,16 @@ Defines the Longhorn action when a Volume is stuck with a Deployment Pod on a fa
 - `wait`: Longhorn will wait to recover the Volume Attachment until all the terminating pods have passed their deletion grace period.
 - `never`: The default Kubernetes behavior of never deleting volume attachments on terminating pods. Longhorn will not recover the Volume Attachment from a failed node.
 - `immediate`: Longhorn will recover the Volume Attachment from the failed node as soon as there are pending replacement pods available.
+
+#### Pod Deletion Policy When Node Downs
+> Default: `do-nothing`
+
+Defines the Longhorn action when a Volume is stuck with a StatefulSet/Deployment Pod on a down node.
+
+- `do-nothing` is the default Kubernetes behavior of never force delete StatefulSet/Deployment terminating pods.
+- `delete-statefulset-pod` Longhorn will force delete StatefulSet terminating pods on down node to release Longhorn volumes so that Kubernetes can spin up replacement pods.
+- `delete-deployment-pod` Longhorn will force delete Deployment terminating pods on down node to release Longhorn volumes so that Kubernetes can spin up replacement pods.
+- `delete-both-statefulset-and-deployment-pod` Longhorn will force delete StatefulSet/Deployment terminating pods on down node to release Longhorn volumes so that Kubernetes can spin up replacement pods.
 
 #### Custom mkfs.ext4 parameters
 


### PR DESCRIPTION
Add document about `Pod Deletion Policy When Node Downs`. Longhorn provides 4 different Pod deletion policies when node downs: `do-nothing`, `delete-statefulset-pod`, `delete-deployment-pod`, `delete-both-statefulset-and-deployment-pod`. User can change the setting in setting tab in Longhorn UI or in `Customizing Default Settings`

Longhorn/longhorn#1105