### PR TITLE
Add documentation for CSI snapshot feature

### DIFF
--- a/content/docs/1.1.0/concepts.md
+++ b/content/docs/1.1.0/concepts.md
@@ -65,8 +65,8 @@ In the figure below,
 
 - There are three containers with Longhorn volumes.
 - Each volume has a dedicated controller, which is called the Longhorn Engine and runs as a container.
-- Each Longhorn volume has two replicas, and each replica is a container. 
-- The arrows in the figure indicate the read/write data flow between the volume, controller container, replica containers, and disks. 
+- Each Longhorn volume has two replicas, and each replica is a container.
+- The arrows in the figure indicate the read/write data flow between the volume, controller container, replica containers, and disks.
 - By creating a separate Longhorn Engine for each volume, if one controller fails, the function of other volumes is not impacted.
 
 **Figure 1. Read/write Data Flow between the Volume, Longhorn Engine, Replica Containers, and Disks**
@@ -87,12 +87,8 @@ Longhorn can create a long-running job to orchestrate the upgrade of all live vo
 
 The Longhorn CSI driver takes the block device, formats it, and mounts it on the node. Then the [kubelet](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/) bind-mounts the device inside a Kubernetes Pod. This allows the Pod to access the Longhorn volume.
 
-The Kubernetes CSI Driver images are:
-
-- CSI Attacher: quay.io/k8scsi/csi-attacher:v2.0.0
-- CSI Provisioner: quay.io/k8scsi/csi-provisioner:v1.4.0
-- CSI Node Driver Registrar: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
-- CSI Resizer: quay.io/k8scsi/csi-resizer:v0.3.0
+The required Kubernetes CSI Driver images will be deployed automatically by the longhorn driver deployer.
+To install Longhorn in an air gapped environment, refer to [this section](../advanced-resources/deploy/airgap).
 
 ## 1.4. CSI Plugin
 
@@ -108,7 +104,7 @@ Longhorn does leverage iSCSI, so extra configuration of the node may be required
 
 The Longhorn UI interacts with the Longhorn Manager through the Longhorn API, and acts as a complement of Kubernetes. Through the Longhorn UI, you can manage snapshots, backups, nodes and disks.
 
-Besides, the space usage of the cluster worker nodes is collected and illustrated by the Longhorn UI. See [here](../volumes-and-nodes/node-space-usage) for details.  
+Besides, the space usage of the cluster worker nodes is collected and illustrated by the Longhorn UI. See [here](../volumes-and-nodes/node-space-usage) for details.
 
 # 2. Longhorn Volumes and Primary Storage
 
@@ -165,7 +161,7 @@ Beyond the read index, we currently do not maintain additional metadata to indic
 **Figure 2. How the Read Index Keeps Track of Which Snapshot Holds the Most Recent Data**
 
 {{< figure alt="how the read index keeps track of which snapshot holds the most recent data" src="/img/diagrams/architecture/read-index.png" >}}
- 
+
 The figure above is color-coded to show which blocks contain the most recent data according to the read index, and the source of the latest data is also listed in the table below:
 
 | Read Index | Source of the latest data |
@@ -379,7 +375,7 @@ In other words, a typical workflow for setting up existing storage in Kubernetes
 1. Add a PVC that refers to the PV.
 1. Mount the PVC as a volume in your workload.
 
-When a PVC requests a piece of storage, the Kubernetes API server will try to match that PVC with a pre-allocated PV as matching volumes become available. If a match can be found, the PVC will be bound to the PV, and the user will start to use that pre-allocated piece of storage. 
+When a PVC requests a piece of storage, the Kubernetes API server will try to match that PVC with a pre-allocated PV as matching volumes become available. If a match can be found, the PVC will be bound to the PV, and the user will start to use that pre-allocated piece of storage.
 
 if a matching volume does not exist, PersistentVolumeClaims will remain unbound indefinitely. For example, a cluster provisioned with many 50 Gi PVs would not match a PVC requesting 100 Gi. The PVC could be bound after a 100 Gi PV is added to the cluster.
 

--- a/content/docs/1.1.0/snapshots-and-backups/csi-snapshot-support/_index.md
+++ b/content/docs/1.1.0/snapshots-and-backups/csi-snapshot-support/_index.md
@@ -1,0 +1,11 @@
+---
+title: CSI Snapshot Support
+description: Creating and Restoring Longhorn Backups via the kubernetes CSI snapshot mechanism
+weight: 3
+---
+
+## History
+- [Github Issue](https://github.com/longhorn/longhorn/issues/304)
+- [Longhorn Enhancement Proposal](https://github.com/longhorn/longhorn/blob/master/enhancements/20200904-csi-snapshot-support.md)
+
+Available since v1.1.0

--- a/content/docs/1.1.0/snapshots-and-backups/csi-snapshot-support/create-a-backup-via-csi.md
+++ b/content/docs/1.1.0/snapshots-and-backups/csi-snapshot-support/create-a-backup-via-csi.md
@@ -1,0 +1,54 @@
+---
+title: Create a Backup via CSI
+weight: 2
+---
+
+Backups in Longhorn are snapshots that are moved off-cluster into a backupstore.
+A backup of a snapshot is copied to the backupstore, and the endpoint to access the backupstore is the backup target.
+
+To programmatically create backups you can use the generic kubernetes csi snapshot mechanism.
+To learn more about the CSI snapshot mechanism, click [here](https://kubernetes.io/docs/concepts/storage/volume-snapshots/).
+
+> **Prerequisite:** CSI snapshot support needs to be enabled on your cluster.
+> If your kubernetes distribution does not provide the kubernetes snapshot controller
+> as well as the snapshot related custom resource definitions, you need to manually deploy them.
+> For more information, see [Enable CSI Snapshot Support](../enable-csi-snapshot-support).
+
+
+#### Create a backup, via the csi mechanism
+
+1. Create a kubernetes `VolumeSnapshot` object via `kubectl` (example object below)
+2. The `VolumeSnapshot.uuid` will be used to identify a **longhorn snapshot** and the associated `VolumeSnapshotContent` object.
+3. This will create a new longhorn snapshot named `snapshot-uuid`
+4. Then a backup of that snapshot will be initiated, and the csi request returns
+5. Afterwards a `VolumeSnapshotContent` named `snapcontent-uuid` will be created
+6. The CSI snapshotter side car will periodically query the longhorn csi plugin to evaluate the backup status
+7. Once the backup is completed, the `VolumeSnapshotContent.readyToUse` flag will be set to **true**
+
+**Result:**
+A backup is created and the `VolumeSnapshotContent.snapshotHandle`
+refers to the backup via `bs://backup-volume/backup-name`.
+
+To see it, click **Backup** in the top navigation bar and navigate to the backup-volume mentioned in the `VolumeSnapshotContent.snapshotHandle`.
+
+For information on how to restore a volume via a `VolumeSnapshot` object,
+refer to [this page.](../restore-a-backup-via-csi)
+
+
+Example `VolumeSnapshot` object below, the source needs to point to the PVC of the Longhorn volume for which a backup should be created.
+The `volumeSnapshotClassName` field points to a `VolumeSnapshotClass`.
+We create a default class named `longhorn`, which uses `Delete` as its `deletionPolicy`.
+```yaml
+apiVersion: snapshot.storage.k8s.io/v1beta1
+kind: VolumeSnapshot
+metadata:
+  name: test-snapshot-pvc
+spec:
+  volumeSnapshotClassName: longhorn
+  source:
+    persistentVolumeClaimName: test-vol
+```
+
+If you want the associated backup for a volume to be retained when the `VolumeSnapshot` is deleted,
+create a new `VolumeSnapshotClass` with `Retain` set as the `deletionPolicy`.
+For more information about snapshot classes, see the kubernetes documentation for [VolumeSnapshotClasses](https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes/).

--- a/content/docs/1.1.0/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
+++ b/content/docs/1.1.0/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
@@ -1,0 +1,45 @@
+---
+title: Enable CSI snapshot support on your cluster
+description: Enable CSI snapshot support for programmatic creation of Longhorn backups
+weight: 1
+---
+
+> **Prerequisite:**
+> CSI snapshot support is available for kubernetes versions >= **1.17**.
+> It is the responsibility of the kubernetes distribution to deploy the snapshot controller as well as the related custom resource definitions.
+> For more information, see [CSI Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/).
+
+#### Add default `VolumeSnapshotClass`
+Ensure availability of the Snapshot Beta CRDs, afterwards create a default `VolumeSnapshotClass`.
+```yaml
+kind: VolumeSnapshotClass
+apiVersion: snapshot.storage.k8s.io/v1beta1
+metadata:
+  name: longhorn
+driver: driver.longhorn.io
+deletionPolicy: Delete
+```
+
+#### If you are updating from a previous Longhorn version in an **airgap** environment
+- update `csi-provisioner` image to `longhornio/csi-provisioner:v1.6.0`
+- add `csi-snapshotter` image for `longhornio/csi-snapshotter:v2.1.1`
+
+#### If your Kubernetes distribution **does not bundle** the snapshot controller
+you may manually install these components by executing the following steps.
+Note that the snapshot controller YAML files mentioned below deploy into the `default` namespace.
+For general use, update the snapshot controller YAMLs with an appropriate **namespace** prior to installing.
+For example, on a Vanilla Kubernetes cluster update the namespace from `default` to `kube-system` prior to issuing the kubectl create command.
+
+Install Snapshot Beta CRDs:
+1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/master/client/config/crd
+2. kubectl create -f client/config/crd
+3. Do this once per cluster
+
+Install Common Snapshot Controller:
+1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/master/deploy/kubernetes/snapshot-controller
+2. Update the namespace to an appropriate value for your environment (e.g. kube-system)
+3. kubectl create -f deploy/kubernetes/snapshot-controller
+4. Do this once per cluster
+
+See the [Usage](https://github.com/kubernetes-csi/external-snapshotter#usage) section from the kubernetes
+external-snapshotter git repo for additional information.

--- a/content/docs/1.1.0/snapshots-and-backups/csi-snapshot-support/restore-a-backup-via-csi.md
+++ b/content/docs/1.1.0/snapshots-and-backups/csi-snapshot-support/restore-a-backup-via-csi.md
@@ -1,0 +1,87 @@
+---
+title: Restore a Backup via CSI
+weight: 3
+---
+
+Longhorn can easily restore backups to a volume.
+For more information on how backups work, refer to the [concepts](../../../concepts/#3-backups-and-secondary-storage) section.
+
+To programmatically restore backups you can use the generic kubernetes csi snapshot mechanism.
+To learn more about the CSI snapshot mechanism, click [here](https://kubernetes.io/docs/concepts/storage/volume-snapshots/).
+
+
+> **Prerequisite:** CSI snapshot support needs to be enabled on your cluster.
+> If your kubernetes distribution does not provide the kubernetes snapshot controller
+> as well as the snapshot related custom resource definitions, you need to manually deploy them.
+> For more information, see [Enable CSI Snapshot Support](../enable-csi-snapshot-support).
+
+
+#### Restore a backup, via a `VolumeSnapshot` object
+create a `PersistentVolumeClaim` object where the `dataSource` field points to an existing `VolumeSnapshot` object.
+
+The csi-provisioner will pick this up and instruct the longhorn csi driver to provision
+a new volume with the data from the associated backup.
+
+Example `PersistentVolumeClaim` the `dataSource` field needs to point to an existing `VolumeSnapshot` object.
+You can use the same mechanism to restore longhorn backups that have not been created via the csi mechanism, see below for an example.
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-restore-snapshot-pvc
+spec:
+  storageClassName: longhorn
+  dataSource:
+    name: test-snapshot-pvc
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+```
+
+
+#### Restore a backup, that has no associated `VolumeSnapshot`
+To restore longhorn backups that have not been created via the CSI mechanism,
+you manually have to create a `VolumeSnapshot` and `VolumeSnapshotContent` object.
+
+Create a `VolumeSnapshotContent` object with the `snapshotHandle` field set to `bs://backup-volume/backup-name`
+The backup-volume and backup-name values can be retrieved from the **Backup** page in the Longhorn UI.
+```yaml
+apiVersion: snapshot.storage.k8s.io/v1beta1
+kind: VolumeSnapshotContent
+metadata:
+  name: test-existing-backup
+spec:
+  volumeSnapshotClassName: longhorn
+  driver: driver.longhorn.io
+  deletionPolicy: Delete
+  source:
+    # NOTE: change this to point to an existing backup on the backupstore
+    snapshotHandle: bs://test-vol/backup-625159fb469e492e
+  volumeSnapshotRef:
+    name: test-snapshot-existing-backup
+    namespace: default
+```
+
+Create the associated `VolumeSnapshot` object with the `name` field set to `test-snapshot-existing-backup`
+where the `source` field refers to a `VolumeSnapshotContent` object via the `volumeSnapshotContentName` field.
+This differs from the creation of a backup in which case the `source`
+field refers to a `PerstistantVolumeClaim` via the `persistentVolumeClaimName` field.
+Only one type of reference can be set for a `VolumeSnapshot` object.
+```yaml
+apiVersion: snapshot.storage.k8s.io/v1beta1
+kind: VolumeSnapshot
+metadata:
+  name: test-snapshot-existing-backup
+spec:
+  volumeSnapshotClassName: longhorn
+  source:
+    volumeSnapshotContentName: test-existing-backup
+```
+
+Now you can create a `PerstistantVolumeClaim` object that refers to the newly created `VolumeSnapshot` object.
+
+For an example see [Restore a backup, via a `VolumeSnapshot` object](#restore-a-backup-via-a-volumesnapshot-object) above.


### PR DESCRIPTION
Issue: longhorn/longhorn#304
LEP: https://github.com/longhorn/longhorn/blob/master/enhancements/20200904-csi-snapshot-support.md

@yasker
The 1.1 release note need to mention the required update of the csi-provisioner and the addition of the csi-snapshotter image for airgap environments.

Also mentioned in the documentation under enable csi support