### PR TITLE
Mention that any Kubernetes-compatible container runtime is sufficient

### DIFF
--- a/content/docs/0.8.0/getting-started/quick-start-with-helm.md
+++ b/content/docs/0.8.0/getting-started/quick-start-with-helm.md
@@ -8,7 +8,7 @@ weight: 5
 ## Quick Start
 
 1. Helm 3.0+
-2. Docker v1.13+
+2. A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
 3. Kubernetes v1.14+ cluster with 1 or more nodes and Mount Propagation feature enabled. If your Kubernetes cluster was provisioned by Rancher v2.0.7+ or later, MountPropagation feature is enabled by default. [Check your Kubernetes environment now](https://github.com/longhorn/longhorn/#environment-check-script). If MountPropagation is disabled, Base Image feature will be disabled.
 4. Make sure `curl`, `findmnt`, `grep`, `awk` and `blkid` has been installed in all nodes of the Kubernetes cluster.
 5.  `open-iscsi` has been installed on all the nodes of the Kubernetes cluster, and `iscsid` daemon is running on all the nodes.

--- a/content/docs/0.8.0/install/install-with-rancher.md
+++ b/content/docs/0.8.0/install/install-with-rancher.md
@@ -11,7 +11,7 @@ If there is a new version of Longhorn available, you will see an `Upgrade Availa
 ## Prerequisites
 
 1. Rancher v2.1+
-2. Docker v1.13+
+2. A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
 3. Kubernetes v1.14+ cluster with 1 or more nodes and Mount Propagation feature enabled. If your Kubernetes cluster was provisioned by Rancher v2.0.7+ or later, MountPropagation feature is enabled by default. [Check your Kubernetes environment now](https://github.com/longhorn/longhorn/#environment-check-script). If MountPropagation is disabled, the Base Image feature will be disabled.
 4. Make sure `curl`, `findmnt`, `grep`, `awk` and `blkid` has been installed in all nodes of the Kubernetes cluster.
 5.  `open-iscsi` has been installed on all the nodes of the Kubernetes cluster, and `iscsid` daemon is running on all the nodes.

--- a/content/docs/0.8.0/install/requirements.md
+++ b/content/docs/0.8.0/install/requirements.md
@@ -3,7 +3,7 @@ title: Installation Requirements
 weight: 1
 ---
 
--  Docker v1.13+
+-  A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
 -  Kubernetes v1.14+.
 -  `open-iscsi` has been installed on all the nodes of the Kubernetes cluster, and `iscsid` daemon is running on all the nodes.
     - For GKE, recommended Ubuntu as guest OS image since it contains open-iscsi already.

--- a/content/docs/0.8.1/deploy/install/_index.md
+++ b/content/docs/0.8.1/deploy/install/_index.md
@@ -20,7 +20,7 @@ For information on deploying Longhorn on specific nodes and rejecting general wo
 
 Each node in the Kubernetes cluster where Longhorn is installed must fulfill the following requirements:
 
--  Docker v1.13+
+-  A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
 -  Kubernetes v1.14+.
 -  `open-iscsi` is installed, and the `iscsid` daemon is running on all the nodes. For help installing `open-iscsi`, refer to [this section.](#installing-open-iscsi)
 - The host filesystem supports the `file extents` feature to store the data. Currently we support:

--- a/content/docs/1.0.0/deploy/install/_index.md
+++ b/content/docs/1.0.0/deploy/install/_index.md
@@ -20,7 +20,7 @@ For information on deploying Longhorn on specific nodes and rejecting general wo
 
 Each node in the Kubernetes cluster where Longhorn is installed must fulfill the following requirements:
 
--  Docker v1.13+
+-  A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
 -  Kubernetes v1.14+.
     - By default Longhorn installation requires a three-nodes cluster since the default replica count is 3 and the [node level soft anti-affinity](https://longhorn.io/docs/1.0.0/references/settings/#replica-node-level-soft-anti-affinity) is disabled.
 -  `open-iscsi` is installed, and the `iscsid` daemon is running on all the nodes. For help installing `open-iscsi`, refer to [this section.](#installing-open-iscsi)

--- a/content/docs/1.0.1/deploy/install/_index.md
+++ b/content/docs/1.0.1/deploy/install/_index.md
@@ -20,7 +20,7 @@ For information on deploying Longhorn on specific nodes and rejecting general wo
 
 Each node in the Kubernetes cluster where Longhorn is installed must fulfill the following requirements:
 
--  Docker v1.13+
+-  A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
 -  Kubernetes v1.14+.
     - By default Longhorn installation requires a three-nodes cluster since the default replica count is 3 and the [node level soft anti-affinity](https://longhorn.io/docs/1.0.0/references/settings/#replica-node-level-soft-anti-affinity) is disabled.
 -  `open-iscsi` is installed, and the `iscsid` daemon is running on all the nodes. For help installing `open-iscsi`, refer to [this section.](#installing-open-iscsi)

--- a/content/docs/1.0.2/deploy/install/_index.md
+++ b/content/docs/1.0.2/deploy/install/_index.md
@@ -20,7 +20,7 @@ For information on deploying Longhorn on specific nodes and rejecting general wo
 
 Each node in the Kubernetes cluster where Longhorn is installed must fulfill the following requirements:
 
--  Docker v1.13+
+-  A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
 -  Kubernetes v1.14+.
     - By default Longhorn installation requires a three-nodes cluster since the default replica count is 3 and the [node level soft anti-affinity](https://longhorn.io/docs/1.0.0/references/settings/#replica-node-level-soft-anti-affinity) is disabled.
 -  `open-iscsi` is installed, and the `iscsid` daemon is running on all the nodes. For help installing `open-iscsi`, refer to [this section.](#installing-open-iscsi)


### PR DESCRIPTION
Longhorn does not specifically require Docker. I went by these requirements and later found out that any Kubernetes container runtime works through [a discussion on Slack](https://rancher-users.slack.com/archives/CC2UQM49Y/p1604669734311000).