### PR TITLE
Fix prometheus feature document so that it makes sense for bot Rancher 2.4- and 2.5+

### DIFF
--- a/content/docs/1.1.0/monitoring/integrating-with-rancher-monitoring.md
+++ b/content/docs/1.1.0/monitoring/integrating-with-rancher-monitoring.md
@@ -6,9 +6,7 @@ weight: 2
 
 Using Rancher, you can monitor the state and processes of your cluster nodes, Kubernetes components, and software deployments through integration with [Prometheus](https://prometheus.io/), a leading open-source monitoring solution.
 
-For each cluster that is enabled for monitoring, Rancher deploys a Prometheus server.
-
-The [Rancher monitoring system](https://rancher.com/docs/rancher/v2.x/en/project-admin/tools/monitoring/) automatically deploys Alertmanager and Grafana for you.
+See [here](https://rancher.com/docs/rancher/v2.x/en/monitoring-alerting/) for the instruction about how to deploy/enable the Rancher monitoring system.
 
 ## Add Longhorn Metrics to the Rancher Monitoring System
 


### PR DESCRIPTION
Rancher 2.5 uses a separate monitoring app for monitoring feature.
This PR update the link so that it makes sense for all Rancher monitoring system  v2.4- and v2.5+.