### PR TITLE
Fix pagination in Docs

### DIFF
--- a/layouts/partials/docs/pagination.html
+++ b/layouts/partials/docs/pagination.html
@@ -1,8 +1,8 @@
-{{ if or .Prev .Next }}
+{{ if or .PrevInSection .NextInSection }}
 <section class="section">
   <div class="container">
     <nav class="pagination" role="navigation" aria-label="pagination">
-      {{ with .Next }}
+      {{ with .NextInSection }}
       <a class="pagination-previous has-text-white has-background-primary" href="{{ .RelPermalink }}">
         <span class="icon">
           <ion-icon name="arrow-back-outline"></ion-icon>
@@ -13,7 +13,7 @@
       </a>
       {{ end }}
 
-      {{ with .Prev }}
+      {{ with .PrevInSection }}
       <a class="pagination-next has-text-white has-background-primary" href="{{ .RelPermalink }}">
         <span>
           {{ .Title }}


### PR DESCRIPTION
Navigate between section pages instead of all regular pages.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

The PR fixes the problem that the previous and next buttons link to the wrong pages, e.g.

![Screen Shot 2020-12-30 at 12 05 24 PM](https://user-images.githubusercontent.com/1691518/103329407-a002fe80-4a97-11eb-8152-9de2eefa07a7.png)
