### PR TITLE
Use release tag to install/upgrade instead of master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repo houses the assets used to build the website for Longhorn, available at
 To run the website locally, you need to have the [Hugo](https://gohugo.io) static site generator installed (installation instructions [here](https://gohugo.io/getting-started/installing/)). Once Hugo is installed:
 
 ```bash
+npm install bulma
 hugo server --buildDrafts --buildFuture
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repo houses the assets used to build the website for Longhorn, available at
 To run the website locally, you need to have the [Hugo](https://gohugo.io) static site generator installed (installation instructions [here](https://gohugo.io/getting-started/installing/)). Once Hugo is installed:
 
 ```bash
-npm install bulma
+yarn install
 hugo server --buildDrafts --buildFuture
 ```
 

--- a/content/docs/0.8.0/install/install-with-kubectl.md
+++ b/content/docs/0.8.0/install/install-with-kubectl.md
@@ -9,7 +9,7 @@ weight: 8
 You can install Longhorn on any Kubernetes cluster using this command:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
 ```
 
 One way to monitor the progress of the installation is to watch Pods being created in the `longhorn-system` namespace:

--- a/content/docs/0.8.0/install/uninstall-longhorn.md
+++ b/content/docs/0.8.0/install/uninstall-longhorn.md
@@ -9,13 +9,13 @@ To prevent damage to the Kubernetes cluster, we recommend deleting all Kubernete
 
 1. Create the uninstallation job to clean up CRDs from the system and wait for success:
   ```
-  kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
+  kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
   kubectl get job/longhorn-uninstall -w
   ```
 
 Example output:
 ```
-$ kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
+$ kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
 serviceaccount/longhorn-uninstall-service-account created
 clusterrole.rbac.authorization.k8s.io/longhorn-uninstall-role created
 clusterrolebinding.rbac.authorization.k8s.io/longhorn-uninstall-bind created
@@ -30,12 +30,12 @@ longhorn-uninstall   1/1           20s        20s
 
 2. Remove remaining components:
   ```
-  kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
-  kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
+  kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
+  kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
   ```
  
-Tip: If you try `kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml` first and get stuck there, 
-pressing `Ctrl C` then running `kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml` can also help you remove Longhorn. Finally, don't forget to cleanup remaining components.
+Tip: If you try `kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml` first and get stuck there, 
+pressing `Ctrl C` then running `kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml` can also help you remove Longhorn. Finally, don't forget to cleanup remaining components.
 
 
 ### Uninstalling Longhorn from the Rancher UI

--- a/content/docs/0.8.0/install/upgrades.md
+++ b/content/docs/0.8.0/install/upgrades.md
@@ -15,7 +15,7 @@ The steps to upgrade Longhorn manager are the same as the installation steps. In
 
 ##### Using kubectl
 ```
-kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
 ```
 
 ##### Using Helm
@@ -113,7 +113,7 @@ We'll use NFS backupstore for this example.
 1. Execute following command to create the backupstore
 
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/nfs-backupstore.yaml
+    kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/backupstores/nfs-backupstore.yaml
     ```
 
 2. On Longhorn UI Settings page, set Backup Target to `nfs://longhorn-test-nfs-svc.default:/opt/backupstore` and click `Save`.

--- a/content/docs/0.8.0/users-guide/backup-and-restore/backupstores-and-backuptargets.md
+++ b/content/docs/0.8.0/users-guide/backup-and-restore/backupstores-and-backuptargets.md
@@ -76,7 +76,7 @@ We provides two testing purpose backupstore based on NFS server and Minio S3 ser
 
 Use following command to setup a Minio S3 server for BackupStore after `longhorn-system` was created.
 ```
-kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/minio-backupstore.yaml
+kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/backupstores/minio-backupstore.yaml
 ```
 
 Now set `Settings/General/BackupTarget` to
@@ -117,4 +117,4 @@ The target URL would looks like:
 nfs://longhorn-test-nfs-svc.default:/opt/backupstore
 ```
 
-You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/master/deploy/backupstores/nfs-backupstore.yaml).
+You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/deploy/backupstores/nfs-backupstore.yaml).

--- a/content/docs/0.8.0/users-guide/create-volumes.md
+++ b/content/docs/0.8.0/users-guide/create-volumes.md
@@ -7,12 +7,12 @@ weight: 1
 Before you create Kubernetes volumes, you must first create a storage class. Use following command to create a StorageClass called `longhorn`.
 
 ```
-kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/storageclass.yaml
+kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/examples/storageclass.yaml
 ```
 
 Now you can create a pod using Longhorn like this:
 ```
-kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/pvc.yaml
+kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/examples/pvc.yaml
 ```
 
 The above yaml file contains two parts:

--- a/content/docs/0.8.0/users-guide/deploy-with-kubernetes.md
+++ b/content/docs/0.8.0/users-guide/deploy-with-kubernetes.md
@@ -6,7 +6,7 @@
 You can install Longhorn on any Kubernetes cluster using kubectl with this command:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
 ```
 
 One way to monitor the progress of the installation is to watch Pods being created in the `longhorn-system` namespace:

--- a/content/docs/0.8.1/advanced-resources/deploy/airgap.md
+++ b/content/docs/0.8.1/advanced-resources/deploy/airgap.md
@@ -16,7 +16,7 @@ weight: 2
 
 1. Get Longhorn Deployment manifest file
 
-    `wget https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml`
+    `wget https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml`
 
 2. Create Longhorn namespace
 

--- a/content/docs/0.8.1/deploy/install/_index.md
+++ b/content/docs/0.8.1/deploy/install/_index.md
@@ -42,7 +42,7 @@ Each node in the Kubernetes cluster where Longhorn is installed must fulfill the
 We've written a script to help you gather enough information about the factors. Before installing, run:
 
 ```shell
-curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/master/scripts/environment_check.sh | bash
+curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/scripts/environment_check.sh | bash
 ```
 
 Example result:

--- a/content/docs/0.8.1/deploy/install/install-with-helm.md
+++ b/content/docs/0.8.1/deploy/install/install-with-helm.md
@@ -10,7 +10,7 @@ In this section, you'll learn how to install Longhorn with Helm.
 - Each node in the Kubernetes cluster where Longhorn will be installed must fulfill [these requirements.](../#installation-requirements)
 - Helm v2.0+ must be installed on your workstation.
 
-[This script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
 
 The initial settings for Longhorn can be [customized using Helm options or by editing the deployment configuration file.](../../../advanced-resources/deploy/customizing-default-settings/#using-helm)
 

--- a/content/docs/0.8.1/deploy/install/install-with-kubectl.md
+++ b/content/docs/0.8.1/deploy/install/install-with-kubectl.md
@@ -8,7 +8,7 @@ weight: 8
 
 Each node in the Kubernetes cluster where Longhorn will be installed must fulfill [these requirements.](../#installation-requirements)
 
-[This script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
 
 The initial settings for Longhorn can be customized by [editing the deployment configuration file.](../../../advanced-resources/deploy/customizing-default-settings/#using-the-longhorn-deployment-yaml-file)
 
@@ -17,7 +17,7 @@ The initial settings for Longhorn can be customized by [editing the deployment c
 1. Install Longhorn on any Kubernetes cluster using this command:
 
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+    kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
     ```
 
     One way to monitor the progress of the installation is to watch pods being created in the `longhorn-system` namespace:

--- a/content/docs/0.8.1/deploy/install/install-with-rancher.md
+++ b/content/docs/0.8.1/deploy/install/install-with-rancher.md
@@ -12,7 +12,7 @@ If there is a new version of Longhorn available, you will see an `Upgrade Availa
 
 Each node in the Kubernetes cluster where Longhorn is installed must fulfill [these requirements.](../#installation-requirements)
 
-[This script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
     
 ## Installation
 

--- a/content/docs/0.8.1/deploy/uninstall/_index.md
+++ b/content/docs/0.8.1/deploy/uninstall/_index.md
@@ -33,13 +33,13 @@ helm delete longhorn --purge
 1. Create the uninstallation job to clean up CRDs from the system and wait for success:
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
     kubectl get job/longhorn-uninstall -w
     ```
 
     Example output:
     ```
-    $ kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
+    $ kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
     serviceaccount/longhorn-uninstall-service-account created
     clusterrole.rbac.authorization.k8s.io/longhorn-uninstall-role created
     clusterrolebinding.rbac.authorization.k8s.io/longhorn-uninstall-bind created
@@ -54,12 +54,12 @@ helm delete longhorn --purge
 
 2. Remove remaining components:
     ```
-    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
-    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
+    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
+    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
     ```
  
-> **Tip:** If you try `kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml` first and get stuck there, 
-pressing `Ctrl C` then running `kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml` can also help you remove Longhorn. Finally, don't forget to cleanup remaining components.
+> **Tip:** If you try `kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml` first and get stuck there, 
+pressing `Ctrl C` then running `kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml` can also help you remove Longhorn. Finally, don't forget to cleanup remaining components.
 
 
 

--- a/content/docs/0.8.1/deploy/upgrade/longhorn-manager.md
+++ b/content/docs/0.8.1/deploy/upgrade/longhorn-manager.md
@@ -14,7 +14,7 @@ weight: 1
 To upgrade with kubectl, run this command:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
 ```
 
 To upgrade with Helm, run this command:

--- a/content/docs/0.8.1/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/0.8.1/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -77,7 +77,7 @@ We provides two testing purpose backupstore based on NFS server and Minio S3 ser
 1. Use following command to setup a Minio S3 server for the backupstore after `longhorn-system` was created.
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/minio-backupstore.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/backupstores/minio-backupstore.yaml
     ```
 
 2. Go to the Longhorn UI. In the top navigation bar, click **Settings.** In the Backup section, set **Backup Target** to
@@ -128,6 +128,6 @@ The target URL should look like this:
 nfs://longhorn-test-nfs-svc.default:/opt/backupstore
 ```
 
-You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/master/deploy/backupstores/nfs-backupstore.yaml).
+You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/deploy/backupstores/nfs-backupstore.yaml).
 
 **Result:** Longhorn can store backups in NFS. To create a backup, see [this section.](../create-a-backup)

--- a/content/docs/0.8.1/volumes-and-nodes/create-volumes.md
+++ b/content/docs/0.8.1/volumes-and-nodes/create-volumes.md
@@ -18,7 +18,7 @@ When the Pod is deployed, the Kubernetes master will check the PersistentVolumeC
 1. Use following command to create a StorageClass called `longhorn`:
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/storageclass.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/examples/storageclass.yaml
     ```
 
     The following example StorageClass is created:
@@ -44,7 +44,7 @@ When the Pod is deployed, the Kubernetes master will check the PersistentVolumeC
 2. Create a Pod that uses Longhorn volumes by running this command:
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/pod_with_pvc.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/examples/pod_with_pvc.yaml
     ```
 
     A Pod named `volume-test` is launched, along with a PersistentVolumeClaim named `longhorn-volv-pvc`. The PersistentVolumeClaim references the Longhorn StorageClass:

--- a/content/docs/1.0.0/advanced-resources/data-recovery/recover-without-system.md
+++ b/content/docs/1.0.0/advanced-resources/data-recovery/recover-without-system.md
@@ -5,7 +5,7 @@ weight: 5
 
 This command gives users the ability to restore a backup to a `raw` image or a `qcow2` image. If the backup is based on a backing file, users should provide the backing file as a `qcow2` image with `--backing file` parameter.
 
-1. Copy the [yaml template](https://github.com/longhorn/longhorn/blob/master/examples/restore_to_file.yaml.template): Make a copy of `examples/restore_to_file.yaml.template` as e.g. `restore.yaml`.
+1. Copy the [yaml template](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/examples/restore_to_file.yaml.template): Make a copy of `examples/restore_to_file.yaml.template` as e.g. `restore.yaml`.
     
 2. Set the node which the output file should be placed on by replacing `<NODE_NAME>`, e.g. `node1`.
 

--- a/content/docs/1.0.0/advanced-resources/deploy/airgap.md
+++ b/content/docs/1.0.0/advanced-resources/deploy/airgap.md
@@ -16,7 +16,7 @@ weight: 2
 
 1. Get Longhorn Deployment manifest file
 
-    `wget https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml`
+    `wget https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml`
 
 2. Create Longhorn namespace
 

--- a/content/docs/1.0.0/deploy/install/_index.md
+++ b/content/docs/1.0.0/deploy/install/_index.md
@@ -47,7 +47,7 @@ For the minimum recommended hardware, refer to the [best practices guide.](../..
 We've written a script to help you gather enough information about the factors. Before installing, run:
 
 ```shell
-curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/master/scripts/environment_check.sh | bash
+curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/scripts/environment_check.sh | bash
 ```
 
 Example result:

--- a/content/docs/1.0.0/deploy/install/install-with-helm.md
+++ b/content/docs/1.0.0/deploy/install/install-with-helm.md
@@ -10,7 +10,7 @@ In this section, you'll learn how to install Longhorn with Helm.
 - Each node in the Kubernetes cluster where Longhorn will be installed must fulfill [these requirements.](../#installation-requirements)
 - Helm v2.0+ must be installed on your workstation.
 
-[This script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
 
 The initial settings for Longhorn can be [customized using Helm options or by editing the deployment configuration file.](../../../advanced-resources/deploy/customizing-default-settings/#using-helm)
 

--- a/content/docs/1.0.0/deploy/install/install-with-kubectl.md
+++ b/content/docs/1.0.0/deploy/install/install-with-kubectl.md
@@ -8,7 +8,7 @@ weight: 8
 
 Each node in the Kubernetes cluster where Longhorn will be installed must fulfill [these requirements.](../#installation-requirements)
 
-[This script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
 
 The initial settings for Longhorn can be customized by [editing the deployment configuration file.](../../../advanced-resources/deploy/customizing-default-settings/#using-the-longhorn-deployment-yaml-file)
 
@@ -17,7 +17,7 @@ The initial settings for Longhorn can be customized by [editing the deployment c
 1. Install Longhorn on any Kubernetes cluster using this command:
 
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+    kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
     ```
 
     One way to monitor the progress of the installation is to watch pods being created in the `longhorn-system` namespace:

--- a/content/docs/1.0.0/deploy/install/install-with-rancher.md
+++ b/content/docs/1.0.0/deploy/install/install-with-rancher.md
@@ -12,7 +12,7 @@ If there is a new version of Longhorn available, you will see an `Upgrade Availa
 
 Each node in the Kubernetes cluster where Longhorn is installed must fulfill [these requirements.](../#installation-requirements)
 
-[This script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
     
 ## Installation
 

--- a/content/docs/1.0.0/deploy/uninstall/_index.md
+++ b/content/docs/1.0.0/deploy/uninstall/_index.md
@@ -33,13 +33,13 @@ helm delete longhorn --purge
 1. Create the uninstallation job to clean up CRDs from the system and wait for success:
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
     kubectl get job/longhorn-uninstall -w
     ```
 
     Example output:
     ```
-    $ kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
+    $ kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
     serviceaccount/longhorn-uninstall-service-account created
     clusterrole.rbac.authorization.k8s.io/longhorn-uninstall-role created
     clusterrolebinding.rbac.authorization.k8s.io/longhorn-uninstall-bind created
@@ -54,12 +54,12 @@ helm delete longhorn --purge
 
 2. Remove remaining components:
     ```
-    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
-    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
+    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
+    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
     ```
  
-> **Tip:** If you try `kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml` first and get stuck there, 
-pressing `Ctrl C` then running `kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml` can also help you remove Longhorn. Finally, don't forget to cleanup remaining components.
+> **Tip:** If you try `kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml` first and get stuck there, 
+pressing `Ctrl C` then running `kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml` can also help you remove Longhorn. Finally, don't forget to cleanup remaining components.
 
 
 

--- a/content/docs/1.0.0/deploy/upgrade/longhorn-manager.md
+++ b/content/docs/1.0.0/deploy/upgrade/longhorn-manager.md
@@ -68,7 +68,7 @@ plugin_watcher.go:212] Removing socket path /var/lib/kubelet/plugins_registry/io
 To upgrade with kubectl, run this command:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
 ```
 
 To upgrade with Helm, run this command:

--- a/content/docs/1.0.0/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/1.0.0/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -81,7 +81,7 @@ We provides two testing purpose backupstore based on NFS server and Minio S3 ser
 1. Use following command to setup a Minio S3 server for the backupstore after `longhorn-system` was created.
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/minio-backupstore.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/backupstores/minio-backupstore.yaml
     ```
 
 2. Go to the Longhorn UI. In the top navigation bar, click **Settings.** In the Backup section, set **Backup Target** to
@@ -132,6 +132,6 @@ The target URL should look like this:
 nfs://longhorn-test-nfs-svc.default:/opt/backupstore
 ```
 
-You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/master/deploy/backupstores/nfs-backupstore.yaml).
+You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/deploy/backupstores/nfs-backupstore.yaml).
 
 **Result:** Longhorn can store backups in NFS. To create a backup, see [this section.](../create-a-backup)

--- a/content/docs/1.0.0/volumes-and-nodes/create-volumes.md
+++ b/content/docs/1.0.0/volumes-and-nodes/create-volumes.md
@@ -18,7 +18,7 @@ When the Pod is deployed, the Kubernetes master will check the PersistentVolumeC
 1. Use following command to create a StorageClass called `longhorn`:
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/storageclass.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/examples/storageclass.yaml
     ```
 
     The following example StorageClass is created:
@@ -44,7 +44,7 @@ When the Pod is deployed, the Kubernetes master will check the PersistentVolumeC
 2. Create a Pod that uses Longhorn volumes by running this command:
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/pod_with_pvc.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/examples/pod_with_pvc.yaml
     ```
 
     A Pod named `volume-test` is launched, along with a PersistentVolumeClaim named `longhorn-volv-pvc`. The PersistentVolumeClaim references the Longhorn StorageClass:

--- a/content/docs/1.0.1/advanced-resources/data-recovery/recover-without-system.md
+++ b/content/docs/1.0.1/advanced-resources/data-recovery/recover-without-system.md
@@ -5,7 +5,7 @@ weight: 5
 
 This command gives users the ability to restore a backup to a `raw` image or a `qcow2` image. If the backup is based on a backing file, users should provide the backing file as a `qcow2` image with `--backing file` parameter.
 
-1. Copy the [yaml template](https://github.com/longhorn/longhorn/blob/master/examples/restore_to_file.yaml.template): Make a copy of `examples/restore_to_file.yaml.template` as e.g. `restore.yaml`.
+1. Copy the [yaml template](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/examples/restore_to_file.yaml.template): Make a copy of `examples/restore_to_file.yaml.template` as e.g. `restore.yaml`.
     
 2. Set the node which the output file should be placed on by replacing `<NODE_NAME>`, e.g. `node1`.
 

--- a/content/docs/1.0.1/advanced-resources/deploy/airgap.md
+++ b/content/docs/1.0.1/advanced-resources/deploy/airgap.md
@@ -35,7 +35,7 @@ weight: 2
 
 1. Get Longhorn Deployment manifest file
 
-    `wget https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml`
+    `wget https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml`
 
 2. Create Longhorn namespace
 

--- a/content/docs/1.0.1/advanced-resources/rwx-workloads.md
+++ b/content/docs/1.0.1/advanced-resources/rwx-workloads.md
@@ -13,9 +13,9 @@ The following diagram shows how the RWX support works:
 
 To enable RWX support you need to deploy the following files:
 
-- [01-security.yaml](https://github.com/longhorn/longhorn/blob/master/examples/rwx/01-security.yaml)
-- [02-longhorn-nfs-provisioner.yaml](https://github.com/longhorn/longhorn/blob/master/examples/rwx/02-longhorn-nfs-provisioner.yaml)
-- [03-rwx-test.yaml](https://github.com/longhorn/longhorn/blob/master/examples/rwx/03-rwx-test.yaml)
+- [01-security.yaml](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/examples/rwx/01-security.yaml)
+- [02-longhorn-nfs-provisioner.yaml](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/examples/rwx/02-longhorn-nfs-provisioner.yaml)
+- [03-rwx-test.yaml](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/examples/rwx/03-rwx-test.yaml)
 
 The `03-rwx-test.yaml` example deployment has four pods that share an RWX volume via NFS mounted at `/mnt/nfs-test`. Every second the pods append the current date and time to a shared log file under `/mnt/nfs-test/test.log`.
 

--- a/content/docs/1.0.1/deploy/install/_index.md
+++ b/content/docs/1.0.1/deploy/install/_index.md
@@ -47,7 +47,7 @@ For the minimum recommended hardware, refer to the [best practices guide.](../..
 We've written a script to help you gather enough information about the factors. Before installing, run:
 
 ```shell
-curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/master/scripts/environment_check.sh | bash
+curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/scripts/environment_check.sh | bash
 ```
 
 Example result:

--- a/content/docs/1.0.1/deploy/install/install-with-helm.md
+++ b/content/docs/1.0.1/deploy/install/install-with-helm.md
@@ -10,7 +10,7 @@ In this section, you'll learn how to install Longhorn with Helm.
 - Each node in the Kubernetes cluster where Longhorn will be installed must fulfill [these requirements.](../#installation-requirements)
 - Helm v2.0+ must be installed on your workstation.
 
-[This script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
 
 The initial settings for Longhorn can be [customized using Helm options or by editing the deployment configuration file.](../../../advanced-resources/deploy/customizing-default-settings/#using-helm)
 

--- a/content/docs/1.0.1/deploy/install/install-with-kubectl.md
+++ b/content/docs/1.0.1/deploy/install/install-with-kubectl.md
@@ -8,7 +8,7 @@ weight: 8
 
 Each node in the Kubernetes cluster where Longhorn will be installed must fulfill [these requirements.](../#installation-requirements)
 
-[This script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
 
 The initial settings for Longhorn can be customized by [editing the deployment configuration file.](../../../advanced-resources/deploy/customizing-default-settings/#using-the-longhorn-deployment-yaml-file)
 
@@ -17,7 +17,7 @@ The initial settings for Longhorn can be customized by [editing the deployment c
 1. Install Longhorn on any Kubernetes cluster using this command:
 
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+    kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
     ```
 
     One way to monitor the progress of the installation is to watch pods being created in the `longhorn-system` namespace:

--- a/content/docs/1.0.1/deploy/install/install-with-rancher.md
+++ b/content/docs/1.0.1/deploy/install/install-with-rancher.md
@@ -12,7 +12,7 @@ If there is a new version of Longhorn available, you will see an `Upgrade Availa
 
 Each node in the Kubernetes cluster where Longhorn is installed must fulfill [these requirements.](../#installation-requirements)
 
-[This script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
     
 ## Installation
 

--- a/content/docs/1.0.1/deploy/uninstall/_index.md
+++ b/content/docs/1.0.1/deploy/uninstall/_index.md
@@ -33,13 +33,13 @@ helm delete longhorn --purge
 1. Create the uninstallation job to clean up CRDs from the system and wait for success:
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
     kubectl get job/longhorn-uninstall -w
     ```
 
     Example output:
     ```
-    $ kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
+    $ kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
     serviceaccount/longhorn-uninstall-service-account created
     clusterrole.rbac.authorization.k8s.io/longhorn-uninstall-role created
     clusterrolebinding.rbac.authorization.k8s.io/longhorn-uninstall-bind created
@@ -54,12 +54,12 @@ helm delete longhorn --purge
 
 2. Remove remaining components:
     ```
-    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
-    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
+    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
+    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
     ```
  
-> **Tip:** If you try `kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml` first and get stuck there, 
-pressing `Ctrl C` then running `kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml` can also help you remove Longhorn. Finally, don't forget to cleanup remaining components.
+> **Tip:** If you try `kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml` first and get stuck there, 
+pressing `Ctrl C` then running `kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml` can also help you remove Longhorn. Finally, don't forget to cleanup remaining components.
 
 
 

--- a/content/docs/1.0.1/deploy/upgrade/longhorn-manager.md
+++ b/content/docs/1.0.1/deploy/upgrade/longhorn-manager.md
@@ -28,7 +28,7 @@ If Longhorn was installed using a Helm Chart, or if it was installed as Rancher 
 To upgrade with kubectl, run this command:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
 ```
 
 To upgrade with Helm, run this command:

--- a/content/docs/1.0.1/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/1.0.1/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -97,7 +97,7 @@ We provides two testing purpose backupstore based on NFS server and Minio S3 ser
 1. Use following command to setup a Minio S3 server for the backupstore after `longhorn-system` was created.
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/minio-backupstore.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/backupstores/minio-backupstore.yaml
     ```
 
 2. Go to the Longhorn UI. In the top navigation bar, click **Settings.** In the Backup section, set **Backup Target** to
@@ -172,6 +172,6 @@ The target URL should look like this:
 nfs://longhorn-test-nfs-svc.default:/opt/backupstore
 ```
 
-You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/master/deploy/backupstores/nfs-backupstore.yaml).
+You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/deploy/backupstores/nfs-backupstore.yaml).
 
 **Result:** Longhorn can store backups in NFS. To create a backup, see [this section.](../create-a-backup)

--- a/content/docs/1.0.1/volumes-and-nodes/create-volumes.md
+++ b/content/docs/1.0.1/volumes-and-nodes/create-volumes.md
@@ -18,7 +18,7 @@ When the Pod is deployed, the Kubernetes master will check the PersistentVolumeC
 1. Use following command to create a StorageClass called `longhorn`:
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/storageclass.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/examples/storageclass.yaml
     ```
 
     The following example StorageClass is created:
@@ -44,7 +44,7 @@ When the Pod is deployed, the Kubernetes master will check the PersistentVolumeC
 2. Create a Pod that uses Longhorn volumes by running this command:
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/pod_with_pvc.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/examples/pod_with_pvc.yaml
     ```
 
     A Pod named `volume-test` is launched, along with a PersistentVolumeClaim named `longhorn-volv-pvc`. The PersistentVolumeClaim references the Longhorn StorageClass:

--- a/content/docs/1.0.2/advanced-resources/data-recovery/recover-without-system.md
+++ b/content/docs/1.0.2/advanced-resources/data-recovery/recover-without-system.md
@@ -5,7 +5,7 @@ weight: 5
 
 This command gives users the ability to restore a backup to a `raw` image or a `qcow2` image. If the backup is based on a backing file, users should provide the backing file as a `qcow2` image with `--backing file` parameter.
 
-1. Copy the [yaml template](https://github.com/longhorn/longhorn/blob/master/examples/restore_to_file.yaml.template): Make a copy of `examples/restore_to_file.yaml.template` as e.g. `restore.yaml`.
+1. Copy the [yaml template](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/examples/restore_to_file.yaml.template): Make a copy of `examples/restore_to_file.yaml.template` as e.g. `restore.yaml`.
     
 2. Set the node which the output file should be placed on by replacing `<NODE_NAME>`, e.g. `node1`.
 

--- a/content/docs/1.0.2/advanced-resources/deploy/airgap.md
+++ b/content/docs/1.0.2/advanced-resources/deploy/airgap.md
@@ -42,7 +42,7 @@ Longhorn can be installed in an air gapped environment by using a manifest file,
 
 1. Get Longhorn Deployment manifest file
 
-    `wget https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml`
+    `wget https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml`
 
 2. Create Longhorn namespace
 

--- a/content/docs/1.0.2/deploy/install/_index.md
+++ b/content/docs/1.0.2/deploy/install/_index.md
@@ -53,7 +53,7 @@ Note `jq` maybe required to be installed locally prior to running env check scri
 To run script:
 
 ```shell
-curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/master/scripts/environment_check.sh | bash
+curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/scripts/environment_check.sh | bash
 ```
 
 Example result:

--- a/content/docs/1.0.2/deploy/install/install-with-helm.md
+++ b/content/docs/1.0.2/deploy/install/install-with-helm.md
@@ -10,7 +10,7 @@ In this section, you'll learn how to install Longhorn with Helm.
 - Each node in the Kubernetes cluster where Longhorn will be installed must fulfill [these requirements.](../#installation-requirements)
 - Helm v2.0+ must be installed on your workstation.
 
-[This script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
 
 The initial settings for Longhorn can be [customized using Helm options or by editing the deployment configuration file.](../../../advanced-resources/deploy/customizing-default-settings/#using-helm)
 

--- a/content/docs/1.0.2/deploy/install/install-with-kubectl.md
+++ b/content/docs/1.0.2/deploy/install/install-with-kubectl.md
@@ -8,7 +8,7 @@ weight: 8
 
 Each node in the Kubernetes cluster where Longhorn will be installed must fulfill [these requirements.](../#installation-requirements)
 
-[This script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
 
 The initial settings for Longhorn can be customized by [editing the deployment configuration file.](../../../advanced-resources/deploy/customizing-default-settings/#using-the-longhorn-deployment-yaml-file)
 
@@ -17,7 +17,7 @@ The initial settings for Longhorn can be customized by [editing the deployment c
 1. Install Longhorn on any Kubernetes cluster using this command:
 
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+    kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
     ```
 
     One way to monitor the progress of the installation is to watch pods being created in the `longhorn-system` namespace:

--- a/content/docs/1.0.2/deploy/install/install-with-rancher.md
+++ b/content/docs/1.0.2/deploy/install/install-with-rancher.md
@@ -12,7 +12,7 @@ If there is a new version of Longhorn available, you will see an `Upgrade Availa
 
 Each node in the Kubernetes cluster where Longhorn is installed must fulfill [these requirements.](../#installation-requirements)
 
-[This script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
     
 ## Installation
 

--- a/content/docs/1.0.2/deploy/upgrade/longhorn-manager.md
+++ b/content/docs/1.0.2/deploy/upgrade/longhorn-manager.md
@@ -32,7 +32,7 @@ If Longhorn was installed using a Helm Chart, or if it was installed as a Ranche
 To upgrade with kubectl, run this command:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
 ```
 
 To upgrade with Helm, run this command:

--- a/content/docs/1.0.2/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/1.0.2/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -101,7 +101,7 @@ We provides two testing purpose backupstore based on NFS server and Minio S3 ser
 1. Use following command to setup a Minio S3 server for the backupstore after `longhorn-system` was created.
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/minio-backupstore.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/backupstores/minio-backupstore.yaml
     ```
 
 2. Go to the Longhorn UI. In the top navigation bar, click **Settings.** In the Backup section, set **Backup Target** to
@@ -176,6 +176,6 @@ The target URL should look like this:
 nfs://longhorn-test-nfs-svc.default:/opt/backupstore
 ```
 
-You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/master/deploy/backupstores/nfs-backupstore.yaml).
+You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/deploy/backupstores/nfs-backupstore.yaml).
 
 **Result:** Longhorn can store backups in NFS. To create a backup, see [this section.](../create-a-backup)

--- a/content/docs/1.1.0/advanced-resources/data-recovery/recover-without-system.md
+++ b/content/docs/1.1.0/advanced-resources/data-recovery/recover-without-system.md
@@ -5,7 +5,7 @@ weight: 5
 
 This command gives users the ability to restore a backup to a `raw` image or a `qcow2` image. If the backup is based on a backing file, users should provide the backing file as a `qcow2` image with `--backing file` parameter.
 
-1. Copy the [yaml template](https://github.com/longhorn/longhorn/blob/master/examples/restore_to_file.yaml.template): Make a copy of `examples/restore_to_file.yaml.template` as e.g. `restore.yaml`.
+1. Copy the [yaml template](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/examples/restore_to_file.yaml.template): Make a copy of `examples/restore_to_file.yaml.template` as e.g. `restore.yaml`.
     
 2. Set the node which the output file should be placed on by replacing `<NODE_NAME>`, e.g. `node1`.
 

--- a/content/docs/1.1.0/advanced-resources/deploy/airgap.md
+++ b/content/docs/1.1.0/advanced-resources/deploy/airgap.md
@@ -16,19 +16,19 @@ Longhorn can be installed in an air gapped environment by using a manifest file,
   - Deploy Kubernetes CSI driver components images to your own registry.
 
 #### Note:
-  - A full list of all needed images is in [longhorn-images.txt](https://raw.githubusercontent.com/longhorn/longhorn/v1.1.0/deploy/longhorn-images.txt). First, download the images list by running:
+  - A full list of all needed images is in [longhorn-images.txt](https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn-images.txt). First, download the images list by running:
     ```shell
-    wget https://raw.githubusercontent.com/longhorn/longhorn/v1.1.0/deploy/longhorn-images.txt
+    wget https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn-images.txt
     ```
-  - We provide a script, [save-images.sh](https://raw.githubusercontent.com/longhorn/longhorn/v1.1.0/scripts/save-images.sh), to quickly pull the above `longhorn-images.txt` list. If you specify a `tar.gz` file name for flag `--images`, the script will save all images to the provided filename. In the example below, the script pulls and saves Longhorn images to the file `longhorn-images.tar.gz`. You then can copy the file to your air-gap environment. On the other hand, if you don't specify the file name, the script just pulls the list of images to your computer.
+  - We provide a script, [save-images.sh](https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/scripts/save-images.sh), to quickly pull the above `longhorn-images.txt` list. If you specify a `tar.gz` file name for flag `--images`, the script will save all images to the provided filename. In the example below, the script pulls and saves Longhorn images to the file `longhorn-images.tar.gz`. You then can copy the file to your air-gap environment. On the other hand, if you don't specify the file name, the script just pulls the list of images to your computer.
     ```shell
-    wget https://raw.githubusercontent.com/longhorn/longhorn/v1.1.0/scripts/save-images.sh
+    wget https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/scripts/save-images.sh
     chmod +x save-images.sh
     ./save-images.sh --image-list longhorn-images.txt --images longhorn-images.tar.gz
     ```
-  - We provide another script, [load-images.sh](https://raw.githubusercontent.com/longhorn/longhorn/v1.1.0/scripts/load-images.sh), to push Longhorn images to your private registry. If you specify a `tar.gz` file name for flag `--images`, the script loads images from the `tar` file and pushes them. Otherwise, it will find images in your local Docker and push them. In the example below, the script loads images from the file `longhorn-images.tar.gz` and pushes them to `<YOUR-PRIVATE-REGISTRY>`
+  - We provide another script, [load-images.sh](https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/scripts/load-images.sh), to push Longhorn images to your private registry. If you specify a `tar.gz` file name for flag `--images`, the script loads images from the `tar` file and pushes them. Otherwise, it will find images in your local Docker and push them. In the example below, the script loads images from the file `longhorn-images.tar.gz` and pushes them to `<YOUR-PRIVATE-REGISTRY>`
     ```shell
-    wget https://raw.githubusercontent.com/longhorn/longhorn/v1.1.0/scripts/load-images.sh
+    wget https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/scripts/load-images.sh
     chmod +x load-images.sh
     ./load-images.sh --image-list longhorn-images.txt --images longhorn-images.tar.gz --registry <YOUR-PRIVATE-REGISTRY>
     ```
@@ -42,7 +42,7 @@ Longhorn can be installed in an air gapped environment by using a manifest file,
 
 1. Get Longhorn Deployment manifest file
 
-    `wget https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml`
+    `wget https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml`
 
 2. Create Longhorn namespace
 
@@ -170,7 +170,7 @@ Longhorn can be installed in an air gapped environment by using a manifest file,
 
 ## Using a Helm Chart
 
-In v1.1.0, Longhorn automatically adds <REGISTRY_URL> prefix to images. You simply need to set the registryUrl parameters to pull images from your private registry.
+In v{{< current-version >}}, Longhorn automatically adds <REGISTRY_URL> prefix to images. You simply need to set the registryUrl parameters to pull images from your private registry.
 
 > **Note:** Once you set registryUrl to your private registry, Longhorn tries to pull images from the registry exclusively. Make sure all Longhorn components' images are in the registry otherwise Longhorn will fail to pull images.
 
@@ -347,4 +347,4 @@ If you keep the images' names as recommended [here](./#recommendation), you only
 ## Recommendation:
 It's highly recommended not to manipulate image tags, especially instance manager image tags such as v1_20200301, because we intentionally use the date to avoid associating it with a Longhorn version.
 
-The images of Longhorn's components are hosted in Dockerhub under the `longhornio` account. For example, `longhornio/longhorn-manager:v1.1.0`. It's recommended to keep the account name, `longhornio`, the same when you push the images to your private registry. This helps avoid unnecessary configuration issues.
+The images of Longhorn's components are hosted in Dockerhub under the `longhornio` account. For example, `longhornio/longhorn-manager:v{{< current-version >}}`. It's recommended to keep the account name, `longhornio`, the same when you push the images to your private registry. This helps avoid unnecessary configuration issues.

--- a/content/docs/1.1.0/deploy/install/_index.md
+++ b/content/docs/1.1.0/deploy/install/_index.md
@@ -53,7 +53,7 @@ Note `jq` maybe required to be installed locally prior to running env check scri
 To run script:
 
 ```shell
-curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/master/scripts/environment_check.sh | bash
+curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/scripts/environment_check.sh | bash
 ```
 
 Example result:
@@ -104,7 +104,7 @@ yum install iscsi-initiator-utils
 
 We also provides an `iscsi` installer to make it easier for users to install `open-iscsi` automatically:
 ```
-kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/iscsi/longhorn-iscsi-installation.yaml
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/iscsi/longhorn-iscsi-installation.yaml
 ```
 After the deployment, run the following command to check pods' status of the installer:
 ```

--- a/content/docs/1.1.0/deploy/install/install-with-helm.md
+++ b/content/docs/1.1.0/deploy/install/install-with-helm.md
@@ -10,7 +10,7 @@ In this section, you'll learn how to install Longhorn with Helm.
 - Each node in the Kubernetes cluster where Longhorn will be installed must fulfill [these requirements.](../#installation-requirements)
 - Helm v2.0+ must be installed on your workstation.
 
-[This script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
 
 The initial settings for Longhorn can be [customized using Helm options or by editing the deployment configuration file.](../../../advanced-resources/deploy/customizing-default-settings/#using-helm)
 

--- a/content/docs/1.1.0/deploy/install/install-with-kubectl.md
+++ b/content/docs/1.1.0/deploy/install/install-with-kubectl.md
@@ -8,7 +8,7 @@ weight: 8
 
 Each node in the Kubernetes cluster where Longhorn will be installed must fulfill [these requirements.](../#installation-requirements)
 
-[This script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
 
 The initial settings for Longhorn can be customized by [editing the deployment configuration file.](../../../advanced-resources/deploy/customizing-default-settings/#using-the-longhorn-deployment-yaml-file)
 
@@ -17,7 +17,7 @@ The initial settings for Longhorn can be customized by [editing the deployment c
 1. Install Longhorn on any Kubernetes cluster using this command:
 
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+    kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
     ```
 
     One way to monitor the progress of the installation is to watch pods being created in the `longhorn-system` namespace:

--- a/content/docs/1.1.0/deploy/install/install-with-rancher.md
+++ b/content/docs/1.1.0/deploy/install/install-with-rancher.md
@@ -12,7 +12,7 @@ If there is a new version of Longhorn available, you will see an `Upgrade Availa
 
 Each node in the Kubernetes cluster where Longhorn is installed must fulfill [these requirements.](../#installation-requirements)
 
-[This script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
     
 ## Installation
 

--- a/content/docs/1.1.0/deploy/uninstall/_index.md
+++ b/content/docs/1.1.0/deploy/uninstall/_index.md
@@ -33,13 +33,13 @@ helm uninstall longhorn -n longhorn-system
 1. Create the uninstallation job to clean up CRDs from the system and wait for success:
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
     kubectl get job/longhorn-uninstall -w
     ```
 
     Example output:
     ```
-    $ kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
+    $ kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
     serviceaccount/longhorn-uninstall-service-account created
     clusterrole.rbac.authorization.k8s.io/longhorn-uninstall-role created
     clusterrolebinding.rbac.authorization.k8s.io/longhorn-uninstall-bind created
@@ -54,12 +54,12 @@ helm uninstall longhorn -n longhorn-system
 
 2. Remove remaining components:
     ```
-    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
-    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
+    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
+    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
     ```
 
-> **Tip:** If you try `kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml` first and get stuck there,
-pressing `Ctrl C` then running `kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml` can also help you remove Longhorn. Finally, don't forget to cleanup remaining components.
+> **Tip:** If you try `kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml` first and get stuck there,
+pressing `Ctrl C` then running `kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml` can also help you remove Longhorn. Finally, don't forget to cleanup remaining components.
 
 
 

--- a/content/docs/1.1.0/deploy/upgrade/longhorn-manager.md
+++ b/content/docs/1.1.0/deploy/upgrade/longhorn-manager.md
@@ -5,13 +5,13 @@ weight: 1
 
 ### Upgrading from v1.0.x
 
-We only support upgrading to v1.1.0 from v1.0.x. For other versions, please upgrade to v1.0.x first.
+We only support upgrading to v{{< current-version >}} from v1.0.x. For other versions, please upgrade to v1.0.x first.
 
-Engine live upgrade is supported from v1.0.x to v1.1.0.
+Engine live upgrade is supported from v1.0.x to v{{< current-version >}}.
 
 For airgap upgrades when Longhorn is installed as a Rancher app, you will need to modify the image names and remove the registry URL part.
 
-For example, the image `registry.example.com/longhorn/longhorn-manager:v1.1.0` is changed to `longhorn/longhorn-manager:v1.1.0` in Longhorn images section. For more information, see the air gap installation steps [here.](../../../advanced-resources/deploy/airgap/#using-a-rancher-app)
+For example, the image `registry.example.com/longhorn/longhorn-manager:v{{< current-version >}}` is changed to `longhorn/longhorn-manager:v{{< current-version >}}` in Longhorn images section. For more information, see the air gap installation steps [here.](../../../advanced-resources/deploy/airgap/#using-a-rancher-app)
 
 #### Preparing for the Upgrade
 
@@ -32,7 +32,7 @@ If Longhorn was installed using a Helm Chart, or if it was installed as Rancher 
 To upgrade with kubectl, run this command:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
 ```
 
 To upgrade with Helm, run this command:
@@ -87,6 +87,6 @@ Next, [upgrade Longhorn engine.](../upgrade-engine)
 
 - To clean up the deprecated StorageClass, run this command:
     ```
-    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v1.0.0/examples/storageclass.yaml
+    kubectl delete -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/examples/storageclass.yaml
     ```
 

--- a/content/docs/1.1.0/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/1.1.0/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -101,7 +101,7 @@ We provides two testing purpose backupstore based on NFS server and Minio S3 ser
 1. Use following command to setup a Minio S3 server for the backupstore after `longhorn-system` was created.
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/backupstores/minio-backupstore.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/backupstores/minio-backupstore.yaml
     ```
 
 2. Go to the Longhorn UI. In the top navigation bar, click **Settings.** In the Backup section, set **Backup Target** to
@@ -176,6 +176,6 @@ The target URL should look like this:
 nfs://longhorn-test-nfs-svc.default:/opt/backupstore
 ```
 
-You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/master/deploy/backupstores/nfs-backupstore.yaml).
+You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/deploy/backupstores/nfs-backupstore.yaml).
 
 **Result:** Longhorn can store backups in NFS. To create a backup, see [this section.](../create-a-backup)

--- a/content/docs/1.1.0/volumes-and-nodes/create-volumes.md
+++ b/content/docs/1.1.0/volumes-and-nodes/create-volumes.md
@@ -18,7 +18,7 @@ When the Pod is deployed, the Kubernetes master will check the PersistentVolumeC
 1. Use following command to create a StorageClass called `longhorn`:
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/storageclass.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/examples/storageclass.yaml
     ```
 
     The following example StorageClass is created:
@@ -44,7 +44,7 @@ When the Pod is deployed, the Kubernetes master will check the PersistentVolumeC
 2. Create a Pod that uses Longhorn volumes by running this command:
 
     ```
-    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/pod_with_pvc.yaml
+    kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/examples/pod_with_pvc.yaml
     ```
 
     A Pod named `volume-test` is launched, along with a PersistentVolumeClaim named `longhorn-volv-pvc`. The PersistentVolumeClaim references the Longhorn StorageClass:

--- a/layouts/shortcodes/current-version.html
+++ b/layouts/shortcodes/current-version.html
@@ -1,0 +1,1 @@
+{{- index (split .Page.File.Dir "/") 1 -}}


### PR DESCRIPTION
Use [shortcode](https://gohugo.io/content-management/shortcodes/) to render the current doc version in the markdown template.

To get the current version, use template `{{- index (split .Page.File.Dir "/") 1 -}}` in `layouts/shortcodes/current-version.html`
Then for each markdown file, use template `v{{< current-version >}}` to render the version.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>