### PR TITLE
Enhance uninstall longhorn

### DIFF
--- a/content/docs/1.1.1/deploy/install/_index.md
+++ b/content/docs/1.1.1/deploy/install/_index.md
@@ -6,9 +6,9 @@ weight: 1
 
 Longhorn can be installed on a Kubernetes cluster in several ways:
 
+- [Rancher catalog app](./install-with-rancher)
 - [kubectl](./install-with-kubectl/)
 - [Helm](./install-with-helm/)
-- [Rancher catalog app](./install-with-rancher)
 
 To install Longhorn in an air gapped environment, refer to [this section.](../../advanced-resources/deploy/airgap)
 

--- a/content/docs/1.1.1/deploy/uninstall/_index.md
+++ b/content/docs/1.1.1/deploy/uninstall/_index.md
@@ -34,7 +34,7 @@ helm uninstall longhorn -n longhorn-system
 
     ```
     kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
-    kubectl get job/longhorn-uninstall -w
+    kubectl get job/longhorn-uninstall -n longhorn-system -w
     ```
 
     Example output:
@@ -45,7 +45,7 @@ helm uninstall longhorn -n longhorn-system
     clusterrolebinding.rbac.authorization.k8s.io/longhorn-uninstall-bind created
     job.batch/longhorn-uninstall created
 
-    $ kubectl get job/longhorn-uninstall -w
+    $ kubectl get job/longhorn-uninstall -n longhorn-system -w
     NAME                 COMPLETIONS   DURATION   AGE
     longhorn-uninstall   0/1           3s         3s
     longhorn-uninstall   1/1           20s        20s


### PR DESCRIPTION
We should specify the namespace when using kubectl command.

#### Issues
https://github.com/longhorn/longhorn/issues/2292