### PR TITLE
Add namespace flag for uninstall job

### DIFF
--- a/content/docs/0.8.1/deploy/uninstall/_index.md
+++ b/content/docs/0.8.1/deploy/uninstall/_index.md
@@ -34,7 +34,7 @@ helm delete longhorn --purge
 
     ```
     kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
-    kubectl get job/longhorn-uninstall -w
+    kubectl get job/longhorn-uninstall -n default -w
     ```
 
     Example output:

--- a/content/docs/1.0.0/deploy/uninstall/_index.md
+++ b/content/docs/1.0.0/deploy/uninstall/_index.md
@@ -34,7 +34,7 @@ helm delete longhorn --purge
 
     ```
     kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
-    kubectl get job/longhorn-uninstall -w
+    kubectl get job/longhorn-uninstall -n default -w
     ```
 
     Example output:

--- a/content/docs/1.0.1/deploy/uninstall/_index.md
+++ b/content/docs/1.0.1/deploy/uninstall/_index.md
@@ -34,7 +34,7 @@ helm delete longhorn --purge
 
     ```
     kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
-    kubectl get job/longhorn-uninstall -w
+    kubectl get job/longhorn-uninstall -n default -w
     ```
 
     Example output:

--- a/content/docs/1.0.2/deploy/uninstall/_index.md
+++ b/content/docs/1.0.2/deploy/uninstall/_index.md
@@ -34,7 +34,7 @@ helm delete longhorn --purge
 
     ```
     kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/uninstall/uninstall.yaml
-    kubectl get job/longhorn-uninstall -w
+    kubectl get job/longhorn-uninstall -n default -w
     ```
 
     Example output:

--- a/content/docs/1.1.0/deploy/uninstall/_index.md
+++ b/content/docs/1.1.0/deploy/uninstall/_index.md
@@ -34,7 +34,7 @@ helm uninstall longhorn -n longhorn-system
 
     ```
     kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/uninstall/uninstall.yaml
-    kubectl get job/longhorn-uninstall -w
+    kubectl get job/longhorn-uninstall -n default -w
     ```
 
     Example output:


### PR DESCRIPTION
We should specify the namespace `default` when using kubectl command.