### PR TITLE
Add version facet filter

### DIFF
--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -28,12 +28,14 @@
 </script>
 
 {{/* Algolia search */}}
+{{ $currentVersion := index (split .Page.File.Dir "/" ) 1 }}
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript">
   docsearch({
     apiKey: '3c4082e162be342fa20a794144b4a479',
     indexName: 'longhorn',
     inputSelector: '#search-input',
+    algoliaOptions: { 'facetFilters': ["version:{{ $currentVersion }}"] },
     debug: false
   });
 </script>


### PR DESCRIPTION
This reverts commit 3ef834535e360e706172300bb3e7f3742b3a0169.

If the user at https://longhorn.io/docs/x.y.z, the Javascript client pass the facet filter with version x.y.z
If the user at https://longhorn.io/ or https://longhorn.io/blog/ or https://longhorn.io/kb/, the JS client won't pass the facet version filter.

related https://github.com/algolia/docsearch-configs/pull/4096
fix #305 

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>