### PR TITLE
Updated default replica count recommendation

### DIFF
--- a/content/docs/1.1.2/references/settings.md
+++ b/content/docs/1.1.2/references/settings.md
@@ -161,7 +161,7 @@ The `storageClassName` is for persistent volumes (PVs) and persistent volume cla
 
 The default number of replicas when creating the volume from Longhorn UI. For Kubernetes, update the `numberOfReplicas` in the StorageClass
 
-The recommended way of choosing the default replica count is: if you have more than three nodes for storage, use 3; otherwise use 2. Using a single replica on a single node cluster is also OK, but the high availability functionality wouldn't be available. You can still take snapshots/backups of the volume.
+The recommended way of choosing the default replica count is: if you have three or more nodes for storage, use 3; otherwise use 2. Using a single replica on a single node cluster is also OK, but the high availability functionality wouldn't be available. You can still take snapshots/backups of the volume.
 
 #### Default Share Manager Image
 


### PR DESCRIPTION
Updated default replica count information. 

Source: https://cloud-native.slack.com/archives/CNVPEL9U3/p1622445869034600

My question:
```
Hey guys! Can anyone explain to me why the default replica count should be set to two instead of three when having three (storage) nodes? From the documentation (https://longhorn.io/docs/0.8.0/users-guide/settings/#default-replica-count):
Note: The recommended way of choosing the default replica count is: if you have more than three nodes for storage, use 3; otherwise use 2. Using a single replica on a single node cluster is also OK, but the HA functionality wouldn't be available. You can still take snapshots/backups of the volume.
I’d rather have it set to three, so I’d like to know the reasoning why Longhorn recommends setting it to two with three (storage) nodes.
```

Answer from @shuo-wu:
```
This description is misleading. Precisely, it means, default replica count can be set to 3 when the storage node number is equal to or larger than 3
```