### PR TITLE
Set crd url to v1beta

### DIFF
--- a/content/docs/1.1.0/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
+++ b/content/docs/1.1.0/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
@@ -40,12 +40,12 @@ Note that the snapshot controller YAML files mentioned below deploy into the `de
 > For example, on a vanilla Kubernetes cluster, update the namespace from `default` to `kube-system` prior to issuing the `kubectl create` command.
 
 Install the Snapshot Beta CRDs:
-1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/master/client/config/crd
+1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/release-4.0/client/config/crd
 2. Run `kubectl create -f client/config/crd`.
 3. Do this once per cluster.
 
 Install the Common Snapshot Controller:
-1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/master/deploy/kubernetes/snapshot-controller
+1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/release-4.0/deploy/kubernetes/snapshot-controller
 2. Update the namespace to an appropriate value for your environment (e.g. `kube-system`)
 3. Run `kubectl create -f deploy/kubernetes/snapshot-controller`.
 3. Do this once per cluster.

--- a/content/docs/1.1.1/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
+++ b/content/docs/1.1.1/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
@@ -40,12 +40,12 @@ Note that the snapshot controller YAML files mentioned below deploy into the `de
 > For example, on a vanilla Kubernetes cluster, update the namespace from `default` to `kube-system` prior to issuing the `kubectl create` command.
 
 Install the Snapshot Beta CRDs:
-1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/master/client/config/crd
+1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/release-4.0/client/config/crd
 2. Run `kubectl create -f client/config/crd`.
 3. Do this once per cluster.
 
 Install the Common Snapshot Controller:
-1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/master/deploy/kubernetes/snapshot-controller
+1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/release-4.0/deploy/kubernetes/snapshot-controller
 2. Update the namespace to an appropriate value for your environment (e.g. `kube-system`)
 3. Run `kubectl create -f deploy/kubernetes/snapshot-controller`.
 3. Do this once per cluster.


### PR DESCRIPTION
Set crd url to v1beta to resolve issue '[BUG] Longhorn document is pointing to the wrong version of CSI snapshot CRDs'

Longhorn: # https://github.com/longhorn/longhorn/issues/2653
Signed-off-by: Clark Hsu <clark.hsu@suse.com>
(cherry picked from commit 4c16fd855773bff6f4c87489698feddf3469d212)