### PR TITLE
Fix incorrect upgrade path for 1.1.1 in the manager upgrade doc

### DIFF
--- a/content/docs/1.1.1/deploy/upgrade/longhorn-manager.md
+++ b/content/docs/1.1.1/deploy/upgrade/longhorn-manager.md
@@ -3,11 +3,11 @@ title: Upgrading Longhorn Manager
 weight: 1
 ---
 
-### Upgrading from v1.0.x
+### Upgrading from v1.1.0
 
-We only support upgrading to v{{< current-version >}} from v1.0.x. For other versions, please upgrade to v1.0.x first.
+We only support upgrading to v{{< current-version >}} from v1.1.0. For other versions, please upgrade to v1.1.0 first.
 
-Engine live upgrade is supported from v1.0.x to v{{< current-version >}}.
+Engine live upgrade is supported from v1.1.0 to v{{< current-version >}}.
 
 For airgap upgrades when Longhorn is installed as a Rancher app, you will need to modify the image names and remove the registry URL part.
 


### PR DESCRIPTION
Signed-off-by: David Ko <dko@suse.com>