### PR TITLE
Use the `latest` url in canonical tag

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -10,6 +10,7 @@
 {{ $versions := site.Params.versions }}
 {{ $latestVersion := index $versions 0 }}
 {{ $currentVersion := index (split .Page.File.Dir "/" ) 1 }}
+{{ $latestURL := $url | replaceRE $currentVersion "latest" }}
 
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -24,7 +25,11 @@
 {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type $url site.Title | safeHTML }}
 {{ end -}}
 
+{{ if $currentVersion }}
+<link rel="canonical" href="{{ $latestURL }}">
+{{ else }}
 <link rel="canonical" href="{{ $url }}">
+{{ end }}
 
 {{/* Twitter Card metadata */}}
 <meta name="twitter:card" content="summary">


### PR DESCRIPTION
To make the search engine do not create duplicate indexing across multiple doc versions, use the `latest` URL in the canonical tag. For example:
- was
```html
<link rel="canonical" href="https://longhorn.io/docs/1.2.0/deploy/install/" />
```
- is
```html
<link rel="canonical" href="https://longhorn.io/docs/latest/deploy/install/" />
```
So, the search engine will only index that page instead of all duplicated version pages.

https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls#rel-canonical-link-method

https://github.com/longhorn/longhorn/issues/2758