### PR TITLE
Fix recurring job format

### DIFF
--- a/content/docs/1.2.0/references/examples.md
+++ b/content/docs/1.2.0/references/examples.md
@@ -413,21 +413,14 @@ For more information about restoring to file, refer to [this section.](../../adv
     #  diskSelector: "ssd,fast"
     #  nodeSelector: "storage,fast"
     #  fsType: "ext4"
-    #  recurringJobs: '[
+    #  recurringJobSelector: '[
     #   {
     #     "name":"snap", 
-    #     "task":"snapshot", 
-    #     "cron":"*/1 * * * *", 
-    #     "retain":1
+    #     "isGroup":true,
     #   },
     #   {
-    #     "name":"backup", 
-    #     "task":"backup", 
-    #     "cron":"*/2 * * * *", 
-    #     "retain":1,
-    #     "labels": {
-    #       "interval":"2m"
-    #      }
+    #     "name":"backup",
+    #     "isGroup":false,
     #   }
     #  ]'
 

--- a/content/docs/1.2.0/volumes-and-nodes/create-volumes.md
+++ b/content/docs/1.2.0/volumes-and-nodes/create-volumes.md
@@ -36,9 +36,16 @@ When the Pod is deployed, the Kubernetes master will check the PersistentVolumeC
       fromBackup: ""
     #  diskSelector: "ssd,fast"
     #  nodeSelector: "storage,fast"
-    #  recurringJobs: '[{"name":"snap", "task":"snapshot", "cron":"*/1 * * * *", "retain":1},
-    #                   {"name":"backup", "task":"backup", "cron":"*/2 * * * *", "retain":1,
-    #                    "labels": {"interval":"2m"}}]'
+    #  recurringJobSelector: '[
+    #   {
+    #     "name":"snap",
+    #     "isGroup":true,
+    #   },
+    #   {
+    #     "name":"backup",
+    #     "isGroup":false,
+    #   }
+    #  ]'
     ```
 
 2. Create a Pod that uses Longhorn volumes by running this command:


### PR DESCRIPTION
Start from v1.2.0, the recurring job format in StorageClass changes to use `recurringJobSelector`.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>