### PR TITLE
Fix Markdown for RecurringJob definition

### DIFF
--- a/content/docs/1.2.1/snapshots-and-backups/scheduling-backups-and-snapshots.md
+++ b/content/docs/1.2.1/snapshots-and-backups/scheduling-backups-and-snapshots.md
@@ -41,6 +41,7 @@ Recurring snapshots and backups can be configured from the `Recurring Job` page 
 ## Set up Recurring Jobs using a Longhorn RecurringJob
 
 Recurring jobs can also be set up by using a Longhorn `RecurringJob`.
+
     apiVersion: longhorn.io/v1beta1
     kind: RecurringJob
     metadata:


### PR DESCRIPTION
Hi, I know, huge change 😄 But docs for 1.2.1 are unreadable here https://longhorn.io/docs/1.2.1/snapshots-and-backups/scheduling-backups-and-snapshots/#set-up-recurring-jobs-using-a-longhorn-recurringjob