### PR TITLE
Remove broken link of Rancher doc

### DIFF
--- a/content/docs/1.1.0/monitoring/integrating-with-rancher-monitoring.md
+++ b/content/docs/1.1.0/monitoring/integrating-with-rancher-monitoring.md
@@ -33,8 +33,8 @@ spec:
 
 Once the ServiceMonitor is created, Rancher will automatically discover all Longhorn metrics.
 
-You can then set up a [Grafana](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/tools/monitoring/viewing-metrics/#grafana) dashboard for visualization.
+You can then set up a Grafana dashboard for visualization.
 
 You can import our prebuilt [Longhorn example dashboard](https://grafana.com/grafana/dashboards/13032) to have an idea.
 
-You can also [set up alerts](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/tools/alerts/) in Rancher UI.
+You can also set up alerts in Rancher UI.

--- a/content/docs/1.1.1/monitoring/integrating-with-rancher-monitoring.md
+++ b/content/docs/1.1.1/monitoring/integrating-with-rancher-monitoring.md
@@ -33,8 +33,8 @@ spec:
 
 Once the ServiceMonitor is created, Rancher will automatically discover all Longhorn metrics.
 
-You can then set up a [Grafana](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/tools/monitoring/viewing-metrics/#grafana) dashboard for visualization.
+You can then set up a Grafana dashboard for visualization.
 
 You can import our prebuilt [Longhorn example dashboard](https://grafana.com/grafana/dashboards/13032) to have an idea.
 
-You can also [set up alerts](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/tools/alerts/) in Rancher UI.
+You can also set up alerts in Rancher UI.

--- a/content/docs/1.1.2/monitoring/integrating-with-rancher-monitoring.md
+++ b/content/docs/1.1.2/monitoring/integrating-with-rancher-monitoring.md
@@ -33,8 +33,8 @@ spec:
 
 Once the ServiceMonitor is created, Rancher will automatically discover all Longhorn metrics.
 
-You can then set up a [Grafana](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/tools/monitoring/viewing-metrics/#grafana) dashboard for visualization.
+You can then set up a Grafana dashboard for visualization.
 
 You can import our prebuilt [Longhorn example dashboard](https://grafana.com/grafana/dashboards/13032) to have an idea.
 
-You can also [set up alerts](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/tools/alerts/) in Rancher UI.
+You can also set up alerts in Rancher UI.

--- a/content/docs/1.2.0/monitoring/integrating-with-rancher-monitoring.md
+++ b/content/docs/1.2.0/monitoring/integrating-with-rancher-monitoring.md
@@ -33,8 +33,8 @@ spec:
 
 Once the ServiceMonitor is created, Rancher will automatically discover all Longhorn metrics.
 
-You can then set up a [Grafana](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/tools/monitoring/viewing-metrics/#grafana) dashboard for visualization.
+You can then set up a Grafana dashboard for visualization.
 
 You can import our prebuilt [Longhorn example dashboard](https://grafana.com/grafana/dashboards/13032) to have an idea.
 
-You can also [set up alerts](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/tools/alerts/) in Rancher UI.
+You can also set up alerts in Rancher UI.

--- a/content/docs/1.2.1/monitoring/integrating-with-rancher-monitoring.md
+++ b/content/docs/1.2.1/monitoring/integrating-with-rancher-monitoring.md
@@ -33,8 +33,8 @@ spec:
 
 Once the ServiceMonitor is created, Rancher will automatically discover all Longhorn metrics.
 
-You can then set up a [Grafana](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/tools/monitoring/viewing-metrics/#grafana) dashboard for visualization.
+You can then set up a Grafana dashboard for visualization.
 
 You can import our prebuilt [Longhorn example dashboard](https://grafana.com/grafana/dashboards/13032) to have an idea.
 
-You can also [set up alerts](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/tools/alerts/) in Rancher UI.
+You can also set up alerts in Rancher UI.

--- a/content/docs/1.2.2/monitoring/integrating-with-rancher-monitoring.md
+++ b/content/docs/1.2.2/monitoring/integrating-with-rancher-monitoring.md
@@ -33,8 +33,8 @@ spec:
 
 Once the ServiceMonitor is created, Rancher will automatically discover all Longhorn metrics.
 
-You can then set up a [Grafana](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/tools/monitoring/viewing-metrics/#grafana) dashboard for visualization.
+You can then set up a Grafana dashboard for visualization.
 
 You can import our prebuilt [Longhorn example dashboard](https://grafana.com/grafana/dashboards/13032) to have an idea.
 
-You can also [set up alerts](https://rancher.com/docs/rancher/v2.x/en/cluster-admin/tools/alerts/) in Rancher UI.
+You can also set up alerts in Rancher UI.


### PR DESCRIPTION
Rancher doc separates to use different URL links, such as v2.0-v2.4, v2.5, v2.6.
To make Longhorn documentation compatible across all Rancher docs, I think we should remove the hyperlink directly.
Then users have to find the related doc by themselves.

https://github.com/longhorn/longhorn/issues/3215