### PR TITLE
Add --pod-selector to the drain instruction

### DIFF
--- a/content/docs/1.2.2/volumes-and-nodes/maintenance.md
+++ b/content/docs/1.2.2/volumes-and-nodes/maintenance.md
@@ -16,7 +16,9 @@ This section describes how to handle planned maintenance of nodes.
 
 1. Drain the node to move the workload to somewhere else.
 
-    You will need to use `--ignore-daemonsets` options to drain the node because Longhorn deployed some daemonsets such as `Longhorn manager`, `Longhorn CSI plugin`, `engine image`.
+    You will need to use `--ignore-daemonsets` and `--pod-selector='app!=csi-attacher,app!=csi-provisioner'` options to drain the node.
+    The `--ignore-daemonsets` is needed because Longhorn deployed some daemonsets such as `Longhorn manager`, `Longhorn CSI plugin`, `engine image`.
+    The `--pod-selector='app!=csi-attacher,app!=csi-provisioner'` is needed so CSI Attacher can properly detaches Longhorn volumes (see the [GitHub issue](https://github.com/longhorn/longhorn/issues/3304) for more detail).
 
     The replica processes on the node will be stopped at this stage. Replicas on
     the node will be shown as `Failed`.


### PR DESCRIPTION
This makes sure that Kubernetes doesn't evict CSI attacher and provisioner so Longhorn can properly detach the volumes

longhorn/longhorn#3304