### PR TITLE
Bump the version of longhorn API to v1beta2.

### DIFF
--- a/content/docs/1.3.0/advanced-resources/backing-image.md
+++ b/content/docs/1.3.0/advanced-resources/backing-image.md
@@ -34,7 +34,7 @@ It's better not to "upload" a file via YAML. Otherwise, you need to manually han
 
 Here are some examples:
 ```yaml
-apiVersion: longhorn.io/v1beta1
+apiVersion: longhorn.io/v1beta2
 kind: BackingImage
 metadata:
   name: bi-download
@@ -46,7 +46,7 @@ spec:
   checksum: 304f3ed30ca6878e9056ee6f1b02b328239f0d0c2c1272840998212f9734b196371560b3b939037e4f4c2884ce457c2cbc9f0621f4f5d1ca983983c8cdf8cd9a
 ```
 ```yaml
-apiVersion: longhorn.io/v1beta1
+apiVersion: longhorn.io/v1beta2
 kind: BackingImage
 metadata:
   name: bi-export

--- a/content/docs/1.3.0/advanced-resources/deploy/airgap.md
+++ b/content/docs/1.3.0/advanced-resources/deploy/airgap.md
@@ -319,7 +319,7 @@ If you keep the images' names as recommended [here](./#recommendation), you only
 2. Create `registry-secret` setting object manually.
 
     ```yaml
-    apiVersion: longhorn.io/v1beta1
+    apiVersion: longhorn.io/v1beta2
     kind: Setting
     metadata:
       name: registry-secret

--- a/content/docs/1.3.0/references/settings.md
+++ b/content/docs/1.3.0/references/settings.md
@@ -116,9 +116,9 @@ Allows setting additional filesystem creation parameters for ext4. For older hos
 
 #### Custom Resource API Version
 
-> Default: `longhorn.io/v1beta1`
+> Default: `longhorn.io/v1beta2`
 
-The current customer resource's API version, e.g. longhorn.io/v1beta1. Set by manager automatically.
+The current customer resource's API version, e.g. longhorn.io/v1beta2. Set by manager automatically.
 
 #### Default Data Locality
 


### PR DESCRIPTION
Update documents with new API version `v1beta2` starting from v1.3.0.

Signed-off-by: James Lu <jamesluhz@gmail.com>