### PR TITLE
Fix transposed 'the' and 'unless'

### DIFF
--- a/content/docs/1.1.0/concepts.md
+++ b/content/docs/1.1.0/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/1.1.1/concepts.md
+++ b/content/docs/1.1.1/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/1.1.2/concepts.md
+++ b/content/docs/1.1.2/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/1.1.3/concepts.md
+++ b/content/docs/1.1.3/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/1.2.0/concepts.md
+++ b/content/docs/1.2.0/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/1.2.1/concepts.md
+++ b/content/docs/1.2.1/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/1.2.2/concepts.md
+++ b/content/docs/1.2.2/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/1.2.3/concepts.md
+++ b/content/docs/1.2.3/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/1.2.4/concepts.md
+++ b/content/docs/1.2.4/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/1.2.5/concepts.md
+++ b/content/docs/1.2.5/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/1.3.0/concepts.md
+++ b/content/docs/1.3.0/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/1.3.1/concepts.md
+++ b/content/docs/1.3.1/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/1.4.0/concepts.md
+++ b/content/docs/1.4.0/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/archives/0.8.0/concepts.md
+++ b/content/docs/archives/0.8.0/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the settings. When a volume is attac
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/archives/0.8.1/concepts.md
+++ b/content/docs/archives/0.8.1/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/archives/1.0.0/concepts.md
+++ b/content/docs/archives/1.0.0/concepts.md
@@ -142,7 +142,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/archives/1.0.1/concepts.md
+++ b/content/docs/archives/1.0.1/concepts.md
@@ -146,7 +146,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 

--- a/content/docs/archives/1.0.2/concepts.md
+++ b/content/docs/archives/1.0.2/concepts.md
@@ -146,7 +146,7 @@ The default replica count can be changed in the [settings.](../references/settin
 
 If the current healthy replica count is less than specified replica count, Longhorn will start rebuilding new replicas.
 
-If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas the unless healthy replica count dips below the specified replica count.
+If the current healthy replica count is more than the specified replica count, Longhorn will do nothing. In this situation, if a replica fails or is deleted, Longhorn won’t start rebuilding new replicas unless the healthy replica count dips below the specified replica count.
 
 Longhorn replicas are built using Linux [sparse files,](https://en.wikipedia.org/wiki/Sparse_file) which support thin provisioning.
 


### PR DESCRIPTION
Signed-off-by: Tim Serong <tserong@suse.com>

(I found this while browsing the 1.3.0 docs online, then discovered it was in all versions so just did a search and replace everywhere - I hope that's the right approach here)