### PR TITLE
Add Prometheus metrics for backup

### DIFF
--- a/content/docs/1.3.0/monitoring/metrics.md
+++ b/content/docs/1.3.0/monitoring/metrics.md
@@ -49,3 +49,10 @@ weight: 3
 |---|---|---|
 | longhorn_manager_cpu_usage_millicpu |  The CPU usage of this Longhorn Manager | longhorn_manager_cpu_usage_millicpu{manager="longhorn-manager-5rx2n",node="worker-2"} 27 |
 | longhorn_manager_memory_usage_bytes | The memory usage of this Longhorn Manager | longhorn_manager_memory_usage_bytes{manager="longhorn-manager-5rx2n",node="worker-2"} 2.6144768e+07|
+
+## Backup
+
+| Name | Description  | Example |
+|---|---|---|
+| longhorn_backup_actual_size_bytes | Actual size of this backup | longhorn_backup_actual_size_bytes{backup="backup-4ab66eca0d60473e",volume="testvol"} 6.291456e+07 |
+| longhorn_backup_state | State of this backup: 0=New, 1=Pending, 2=InProgress, 3=Completed, 4=Error, 5=Unknown | longhorn_backup_state{backup="backup-4ab66eca0d60473e",volume="testvol"} 3 |

--- a/content/docs/1.3.1/monitoring/metrics.md
+++ b/content/docs/1.3.1/monitoring/metrics.md
@@ -49,3 +49,10 @@ weight: 3
 |---|---|---|
 | longhorn_manager_cpu_usage_millicpu |  The CPU usage of this Longhorn Manager | longhorn_manager_cpu_usage_millicpu{manager="longhorn-manager-5rx2n",node="worker-2"} 27 |
 | longhorn_manager_memory_usage_bytes | The memory usage of this Longhorn Manager | longhorn_manager_memory_usage_bytes{manager="longhorn-manager-5rx2n",node="worker-2"} 2.6144768e+07|
+
+## Backup
+
+| Name | Description  | Example |
+|---|---|---|
+| longhorn_backup_actual_size_bytes | Actual size of this backup | longhorn_backup_actual_size_bytes{backup="backup-4ab66eca0d60473e",volume="testvol"} 6.291456e+07 |
+| longhorn_backup_state | State of this backup: 0=New, 1=Pending, 2=InProgress, 3=Completed, 4=Error, 5=Unknown | longhorn_backup_state{backup="backup-4ab66eca0d60473e",volume="testvol"} 3 |

--- a/content/docs/1.4.0/monitoring/metrics.md
+++ b/content/docs/1.4.0/monitoring/metrics.md
@@ -49,3 +49,10 @@ weight: 3
 |---|---|---|
 | longhorn_manager_cpu_usage_millicpu |  The CPU usage of this Longhorn Manager | longhorn_manager_cpu_usage_millicpu{manager="longhorn-manager-5rx2n",node="worker-2"} 27 |
 | longhorn_manager_memory_usage_bytes | The memory usage of this Longhorn Manager | longhorn_manager_memory_usage_bytes{manager="longhorn-manager-5rx2n",node="worker-2"} 2.6144768e+07|
+
+## Backup
+
+| Name | Description  | Example |
+|---|---|---|
+| longhorn_backup_actual_size_bytes | Actual size of this backup | longhorn_backup_actual_size_bytes{backup="backup-4ab66eca0d60473e",volume="testvol"} 6.291456e+07 |
+| longhorn_backup_state | State of this backup: 0=New, 1=Pending, 2=InProgress, 3=Completed, 4=Error, 5=Unknown | longhorn_backup_state{backup="backup-4ab66eca0d60473e",volume="testvol"} 3 |


### PR DESCRIPTION
Add Prometheus metrics for backup

From JenTing Hsiao <jenting.hsiao@suse.com>
Add the Prometheus metrics for backup into 1.3.1 and 1.4.0 documents.

longhorn/longhorn#4521

Signed-off-by: James Lu <james.lu@suse.com>