### PR TITLE
docs(deploy): Update v1.3.2/3 the Environment Check Script output result

### DIFF
--- a/content/docs/1.3.2/deploy/install/_index.md
+++ b/content/docs/1.3.2/deploy/install/_index.md
@@ -61,15 +61,12 @@ curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-vers
 Example result:
 
 ```shell
-daemonset.apps/longhorn-environment-check created
-waiting for pods to become ready (0/3)
-all pods ready (3/3)
-
-  MountPropagation is enabled!
-
-cleaning up...
-daemonset.apps "longhorn-environment-check" deleted
-clean up complete
+[INFO]  Required dependencies are installed.
+[INFO]  Waiting for longhorn-environment-check pods to become ready (0/3)...
+[INFO]  All longhorn-environment-check pods are ready (3/3).
+[INFO]  Required packages are installed.
+[INFO]  Cleaning up longhorn-environment-check pods...
+[INFO]  Cleanup completed.
 ```
 
 ### Pod Security Policy

--- a/content/docs/1.3.3/deploy/install/_index.md
+++ b/content/docs/1.3.3/deploy/install/_index.md
@@ -61,15 +61,12 @@ curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-vers
 Example result:
 
 ```shell
-daemonset.apps/longhorn-environment-check created
-waiting for pods to become ready (0/3)
-all pods ready (3/3)
-
-  MountPropagation is enabled!
-
-cleaning up...
-daemonset.apps "longhorn-environment-check" deleted
-clean up complete
+[INFO]  Required dependencies are installed.
+[INFO]  Waiting for longhorn-environment-check pods to become ready (0/3)...
+[INFO]  All longhorn-environment-check pods are ready (3/3).
+[INFO]  Required packages are installed.
+[INFO]  Cleaning up longhorn-environment-check pods...
+[INFO]  Cleanup completed.
 ```
 
 ### Pod Security Policy


### PR DESCRIPTION
[Longhorn 4450](https://github.com/longhorn/longhorn/issues/4450)

Since the [PR#592](https://github.com/longhorn/website/pull/592) branch doesn't have 1.3.2 and 1.3.3, this PR will align the docs for > 1.2.5.  (ref. https://github.com/longhorn/longhorn/issues/4450#issuecomment-1294479499)

Signed-off-by: Ray Chang <ray.chang@suse.com>
