### PR TITLE
Remove experimental from ARM64 in v1.4.0

### DIFF
--- a/content/docs/1.4.0/best-practices.md
+++ b/content/docs/1.4.0/best-practices.md
@@ -38,7 +38,7 @@ We recommend the following setup for deploying Longhorn in production.
 Longhorn supports the following architectures:
 
 1. AMD64
-1. ARM64 (experimental)
+1. ARM64
 1. s390x (experimental)
 
 ## Operating System


### PR DESCRIPTION
Signed-off-by: Chris Chien <chris.chien@suse.com>

From https://github.com/longhorn/longhorn/issues/4206#issuecomment-1305688968, remove experimental from ARM64 in v1.4.0