### PR TITLE
docs: add `failed-backup-tll` to setting reference

### DIFF
--- a/content/docs/1.2.5/references/settings.md
+++ b/content/docs/1.2.5/references/settings.md
@@ -34,6 +34,7 @@ weight: 1
   - [Backup Target](#backup-target)
   - [Backup Target Credential Secret](#backup-target-credential-secret)
   - [Backupstore Poll Interval](#backupstore-poll-interval)
+  - [Failed Backup Time To Live](#failed-backup-time-to-live)
 - [Scheduling](#scheduling)
   - [Allow Volume Creation with Degraded Availability](#allow-volume-creation-with-degraded-availability)
   - [Disable Scheduling On Cordoned Node](#disable-scheduling-on-cordoned-node)
@@ -47,8 +48,8 @@ weight: 1
   - [Guaranteed Engine Manager CPU](#guaranteed-engine-manager-cpu)
   - [Guaranteed Replica Manager CPU](#guaranteed-replica-manager-cpu)
   - [Kubernetes Taint Toleration](#kubernetes-taint-toleration)
-  - [System Managed Components Node Selector](#system-managed-components-node-selector)
   - [Priority Class](#priority-class)
+  - [System Managed Components Node Selector](#system-managed-components-node-selector)
 - [Deprecated](#deprecated)
   - [Guaranteed Engine CPU](#guaranteed-engine-cpu)
   - [Disable Replica Rebuild](#disable-replica-rebuild)
@@ -269,6 +270,14 @@ The Kubernetes secret associated with the backup target. See [Setting a Backup T
 The interval in seconds to poll the backup store for updating volumes' **Last Backup** field. Set to 0 to disable the polling. See [Setting up Disaster Recovery Volumes](../../snapshots-and-backups/setup-disaster-recovery-volumes) for details.
 
 For more information on how the backupstore poll interval affects the recovery time objective and recovery point objective, refer to the [concepts section.](../../concepts/#34-backupstore-update-intervals-rto-and-rpo)
+
+#### Failed Backup Time To Live
+
+> Default: `1440`
+
+The interval in minutes to keep the backup resource that was failed. Set to 0 to disable the auto-deletion.
+
+Failed backups will be checked and cleaned up during backupstore polling which is controlled by **Backupstore Poll Interval** setting. Hence this value determines the minimal wait interval of the cleanup. And the actual cleanup interval is multiple of **Backupstore Poll Interval**. Disabling **Backupstore Poll Interval** also means to disable failed backup auto-deletion.
 
 ### Scheduling
 

--- a/content/docs/1.2.6/references/settings.md
+++ b/content/docs/1.2.6/references/settings.md
@@ -34,6 +34,7 @@ weight: 1
   - [Backup Target](#backup-target)
   - [Backup Target Credential Secret](#backup-target-credential-secret)
   - [Backupstore Poll Interval](#backupstore-poll-interval)
+  - [Failed Backup Time To Live](#failed-backup-time-to-live)
 - [Scheduling](#scheduling)
   - [Allow Volume Creation with Degraded Availability](#allow-volume-creation-with-degraded-availability)
   - [Disable Scheduling On Cordoned Node](#disable-scheduling-on-cordoned-node)
@@ -47,8 +48,8 @@ weight: 1
   - [Guaranteed Engine Manager CPU](#guaranteed-engine-manager-cpu)
   - [Guaranteed Replica Manager CPU](#guaranteed-replica-manager-cpu)
   - [Kubernetes Taint Toleration](#kubernetes-taint-toleration)
-  - [System Managed Components Node Selector](#system-managed-components-node-selector)
   - [Priority Class](#priority-class)
+  - [System Managed Components Node Selector](#system-managed-components-node-selector)
 - [Deprecated](#deprecated)
   - [Guaranteed Engine CPU](#guaranteed-engine-cpu)
   - [Disable Replica Rebuild](#disable-replica-rebuild)
@@ -269,6 +270,14 @@ The Kubernetes secret associated with the backup target. See [Setting a Backup T
 The interval in seconds to poll the backup store for updating volumes' **Last Backup** field. Set to 0 to disable the polling. See [Setting up Disaster Recovery Volumes](../../snapshots-and-backups/setup-disaster-recovery-volumes) for details.
 
 For more information on how the backupstore poll interval affects the recovery time objective and recovery point objective, refer to the [concepts section.](../../concepts/#34-backupstore-update-intervals-rto-and-rpo)
+
+#### Failed Backup Time To Live
+
+> Default: `1440`
+
+The interval in minutes to keep the backup resource that was failed. Set to 0 to disable the auto-deletion.
+
+Failed backups will be checked and cleaned up during backupstore polling which is controlled by **Backupstore Poll Interval** setting. Hence this value determines the minimal wait interval of the cleanup. And the actual cleanup interval is multiple of **Backupstore Poll Interval**. Disabling **Backupstore Poll Interval** also means to disable failed backup auto-deletion.
 
 ### Scheduling
 

--- a/content/docs/1.2.7/references/settings.md
+++ b/content/docs/1.2.7/references/settings.md
@@ -34,6 +34,7 @@ weight: 1
   - [Backup Target](#backup-target)
   - [Backup Target Credential Secret](#backup-target-credential-secret)
   - [Backupstore Poll Interval](#backupstore-poll-interval)
+  - [Failed Backup Time To Live](#failed-backup-time-to-live)
 - [Scheduling](#scheduling)
   - [Allow Volume Creation with Degraded Availability](#allow-volume-creation-with-degraded-availability)
   - [Disable Scheduling On Cordoned Node](#disable-scheduling-on-cordoned-node)
@@ -47,8 +48,8 @@ weight: 1
   - [Guaranteed Engine Manager CPU](#guaranteed-engine-manager-cpu)
   - [Guaranteed Replica Manager CPU](#guaranteed-replica-manager-cpu)
   - [Kubernetes Taint Toleration](#kubernetes-taint-toleration)
-  - [System Managed Components Node Selector](#system-managed-components-node-selector)
   - [Priority Class](#priority-class)
+  - [System Managed Components Node Selector](#system-managed-components-node-selector)
 - [Deprecated](#deprecated)
   - [Guaranteed Engine CPU](#guaranteed-engine-cpu)
   - [Disable Replica Rebuild](#disable-replica-rebuild)
@@ -269,6 +270,14 @@ The Kubernetes secret associated with the backup target. See [Setting a Backup T
 The interval in seconds to poll the backup store for updating volumes' **Last Backup** field. Set to 0 to disable the polling. See [Setting up Disaster Recovery Volumes](../../snapshots-and-backups/setup-disaster-recovery-volumes) for details.
 
 For more information on how the backupstore poll interval affects the recovery time objective and recovery point objective, refer to the [concepts section.](../../concepts/#34-backupstore-update-intervals-rto-and-rpo)
+
+#### Failed Backup Time To Live
+
+> Default: `1440`
+
+The interval in minutes to keep the backup resource that was failed. Set to 0 to disable the auto-deletion.
+
+Failed backups will be checked and cleaned up during backupstore polling which is controlled by **Backupstore Poll Interval** setting. Hence this value determines the minimal wait interval of the cleanup. And the actual cleanup interval is multiple of **Backupstore Poll Interval**. Disabling **Backupstore Poll Interval** also means to disable failed backup auto-deletion.
 
 ### Scheduling
 

--- a/content/docs/1.3.2/references/settings.md
+++ b/content/docs/1.3.2/references/settings.md
@@ -35,6 +35,7 @@ weight: 1
   - [Backup Target](#backup-target)
   - [Backup Target Credential Secret](#backup-target-credential-secret)
   - [Backupstore Poll Interval](#backupstore-poll-interval)
+  - [Failed Backup Time To Live](#failed-backup-time-to-live)
 - [Scheduling](#scheduling)
   - [Allow Volume Creation with Degraded Availability](#allow-volume-creation-with-degraded-availability)
   - [Disable Scheduling On Cordoned Node](#disable-scheduling-on-cordoned-node)
@@ -277,6 +278,14 @@ The Kubernetes secret associated with the backup target. See [Setting a Backup T
 The interval in seconds to poll the backup store for updating volumes' **Last Backup** field. Set to 0 to disable the polling. See [Setting up Disaster Recovery Volumes](../../snapshots-and-backups/setup-disaster-recovery-volumes) for details.
 
 For more information on how the backupstore poll interval affects the recovery time objective and recovery point objective, refer to the [concepts section.](../../concepts/#34-backupstore-update-intervals-rto-and-rpo)
+
+#### Failed Backup Time To Live
+
+> Default: `1440`
+
+The interval in minutes to keep the backup resource that was failed. Set to 0 to disable the auto-deletion.
+
+Failed backups will be checked and cleaned up during backupstore polling which is controlled by **Backupstore Poll Interval** setting. Hence this value determines the minimal wait interval of the cleanup. And the actual cleanup interval is multiple of **Backupstore Poll Interval**. Disabling **Backupstore Poll Interval** also means to disable failed backup auto-deletion.
 
 ### Scheduling
 

--- a/content/docs/1.3.3/references/settings.md
+++ b/content/docs/1.3.3/references/settings.md
@@ -35,6 +35,7 @@ weight: 1
   - [Backup Target](#backup-target)
   - [Backup Target Credential Secret](#backup-target-credential-secret)
   - [Backupstore Poll Interval](#backupstore-poll-interval)
+  - [Failed Backup Time To Live](#failed-backup-time-to-live)
 - [Scheduling](#scheduling)
   - [Allow Volume Creation with Degraded Availability](#allow-volume-creation-with-degraded-availability)
   - [Disable Scheduling On Cordoned Node](#disable-scheduling-on-cordoned-node)
@@ -277,6 +278,14 @@ The Kubernetes secret associated with the backup target. See [Setting a Backup T
 The interval in seconds to poll the backup store for updating volumes' **Last Backup** field. Set to 0 to disable the polling. See [Setting up Disaster Recovery Volumes](../../snapshots-and-backups/setup-disaster-recovery-volumes) for details.
 
 For more information on how the backupstore poll interval affects the recovery time objective and recovery point objective, refer to the [concepts section.](../../concepts/#34-backupstore-update-intervals-rto-and-rpo)
+
+#### Failed Backup Time To Live
+
+> Default: `1440`
+
+The interval in minutes to keep the backup resource that was failed. Set to 0 to disable the auto-deletion.
+
+Failed backups will be checked and cleaned up during backupstore polling which is controlled by **Backupstore Poll Interval** setting. Hence this value determines the minimal wait interval of the cleanup. And the actual cleanup interval is multiple of **Backupstore Poll Interval**. Disabling **Backupstore Poll Interval** also means to disable failed backup auto-deletion.
 
 ### Scheduling
 

--- a/content/docs/1.4.0/references/settings.md
+++ b/content/docs/1.4.0/references/settings.md
@@ -37,6 +37,7 @@ weight: 1
   - [Backup Target](#backup-target)
   - [Backup Target Credential Secret](#backup-target-credential-secret)
   - [Backupstore Poll Interval](#backupstore-poll-interval)
+  - [Failed Backup Time To Live](#failed-backup-time-to-live)
 - [Scheduling](#scheduling)
   - [Allow Volume Creation with Degraded Availability](#allow-volume-creation-with-degraded-availability)
   - [Disable Scheduling On Cordoned Node](#disable-scheduling-on-cordoned-node)
@@ -291,6 +292,14 @@ The Kubernetes secret associated with the backup target. See [Setting a Backup T
 The interval in seconds to poll the backup store for updating volumes' **Last Backup** field. Set to 0 to disable the polling. See [Setting up Disaster Recovery Volumes](../../snapshots-and-backups/setup-disaster-recovery-volumes) for details.
 
 For more information on how the backupstore poll interval affects the recovery time objective and recovery point objective, refer to the [concepts section.](../../concepts/#34-backupstore-update-intervals-rto-and-rpo)
+
+#### Failed Backup Time To Live
+
+> Default: `1440`
+
+The interval in minutes to keep the backup resource that was failed. Set to 0 to disable the auto-deletion.
+
+Failed backups will be checked and cleaned up during backupstore polling which is controlled by **Backupstore Poll Interval** setting. Hence this value determines the minimal wait interval of the cleanup. And the actual cleanup interval is multiple of **Backupstore Poll Interval**. Disabling **Backupstore Poll Interval** also means to disable failed backup auto-deletion.
 
 ### Scheduling
 


### PR DESCRIPTION
Add failed backup TTL to setting reference including default value and its properties.

longhorn/longhorn#4913
longhorn/longhorn#3898