### PR TITLE
Update `LH Grafana dashboard` link in grafana-setup

### DIFF
--- a/content/docs/1.4.0/monitoring/prometheus-and-grafana-setup.md
+++ b/content/docs/1.4.0/monitoring/prometheus-and-grafana-setup.md
@@ -392,7 +392,7 @@ See [Prometheus - Configuration](https://prometheus.io/docs/alerting/latest/conf
 
 1. Setup Longhorn dashboard.
 
-    Once inside Grafana, import the prebuilt [Longhorn example dashboard](https://grafana.com/grafana/dashboards/13032).
+    Once inside Grafana, import the prebuilt [Longhorn example dashboard](https://grafana.com/grafana/dashboards/17626).
 
     See [Grafana Lab - Export and import](https://grafana.com/docs/grafana/latest/reference/export_import/) for instructions on how to import a Grafana dashboard.
 


### PR DESCRIPTION
@derekbit created the LH Grafana dashboard for **v1.4.0**

We need to update LH document in [setting up Grafana](https://longhorn.io/docs/1.4.0/monitoring/prometheus-and-grafana-setup/#setup-grafana)
issue longhorn/longhorn#5158

Signed-off-by: Roger Yao <roger.yao@suse.com>