### PR TITLE
Bump CSI sidecars for K8s v1.20+ and Longhorn v1.5

### DIFF
--- a/content/docs/1.5.0/deploy/important-notes/index.md
+++ b/content/docs/1.5.0/deploy/important-notes/index.md
@@ -53,11 +53,12 @@ For example, adding the following labels to the namespace that is running Longho
         pod-security.kubernetes.io/warn-version: latest
    	```
 
-### Updating CSI Snapshot CRD `v1beta1` to `v1`, `v1beta1` Deprecated
+### Updating CSI Snapshot CRD `v1beta1` to `v1`, `v1beta1` Removed
 
-The CSI snapshot CRDs `v1beta1` version is being deprecated and replaced by `v1` version,
-please follow the instruction [Enable CSI Snapshot Support](../../snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support) to update CSI snapshot CRDs and CSI snapshot controller.
-If you have manifests or scripts that are still using `v1beta1` version, consider upgrading them to use `v1` as well.
+Support for the `v1beta1` version of CSI snapshot CRDs was previously deprecated in favor of the `v1` version. 
+The CSI components in Longhorn v{{< current-version >}} only function with the `v1` version.
+Please follow the instructions at [Enable CSI Snapshot Support](../../snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support) to update CSI snapshot CRDs and the CSI snapshot controller.
+If you have Longhorn volume manifests or scripts that are still using `v1beta1` version, you must upgrade them to `v1` as well.
 
 ### Add StorageClass Parameter `mkfsParams` and [`Custom mkfs.ext4 parameters`](../../references/settings/#custom-mkfsext4-parameters) Setting Deprecated
 

--- a/content/docs/1.5.0/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
+++ b/content/docs/1.5.0/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
@@ -24,14 +24,14 @@ You may manually install these components by executing the following steps.
 > For example, on a vanilla Kubernetes cluster, update the namespace from `default` to `kube-system` prior to issuing the `kubectl create` command.
 
 Install the Snapshot CRDs:
-1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v5.0.1/client/config/crd
-because Longhorn v{{< current-version >}} uses [CSI external-snapshotter](https://kubernetes-csi.github.io/docs/external-snapshotter.html) v5.0.1
+1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v6.2.1/client/config/crd
+because Longhorn v{{< current-version >}} uses [CSI external-snapshotter](https://kubernetes-csi.github.io/docs/external-snapshotter.html) v6.2.1
 2. Run `kubectl create -f client/config/crd`.
 3. Do this once per cluster.
 
 Install the Common Snapshot Controller:
-1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v5.0.1/deploy/kubernetes/snapshot-controller
-because Longhorn v{{< current-version >}} uses [CSI external-snapshotter](https://kubernetes-csi.github.io/docs/external-snapshotter.html) v5.0.1
+1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v6.2.1/deploy/kubernetes/snapshot-controller
+because Longhorn v{{< current-version >}} uses [CSI external-snapshotter](https://kubernetes-csi.github.io/docs/external-snapshotter.html) v6.2.1
 2. Update the namespace to an appropriate value for your environment (e.g. `kube-system`)
 3. Run `kubectl create -f deploy/kubernetes/snapshot-controller`.
 3. Do this once per cluster.


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/5672

We can't move to these versions of external-provisioner and external-snapshotter in Longhorn < v1.5, as they no longer support the v1beta1 VolumeSnapshot API. We deprecated its use in Longhorn v1.4 (https://github.com/longhorn/longhorn/blob/master/CHANGELOG/CHANGELOG-1.4.0.md#deprecation--incompatibilities).

EDIT: This comment was previously (incorrectly) missing the "<" sign.