### PR TITLE
Remove deprecated mkfs-ext4-parameters setting

### DIFF
--- a/content/docs/1.5.0/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/1.5.0/advanced-resources/deploy/customizing-default-settings.md
@@ -75,7 +75,6 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Insta
         #replica-zone-soft-anti-affinity:
         #node-down-pod-deletion-policy:
         #allow-node-drain-with-last-healthy-replica:
-        #mkfs-ext4-parameters:
         #disable-replica-rebuild:
         #replica-replenishment-wait-interval:
         #concurrent-replica-rebuild-per-node-limit:
@@ -150,7 +149,6 @@ You can also provide a copy of the `values.yaml` file with the default settings 
       replicaZoneSoftAntiAffinity: false
       volumeAttachmentRecoveryPolicy: never
       nodeDownPodDeletionPolicy: do-nothing
-      mkfsExt4Parameters: -O ^64bit,^metadata_csum
       guaranteedEngineManagerCpu: 15
       guaranteedReplicaManagerCpu: 15
       orphanAutoDeletion: false

--- a/content/docs/1.5.0/deploy/important-notes/index.md
+++ b/content/docs/1.5.0/deploy/important-notes/index.md
@@ -62,9 +62,9 @@ The CSI components in Longhorn v{{< current-version >}} only function with the `
 Please follow the instructions at [Enable CSI Snapshot Support](../../snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support) to update CSI snapshot CRDs and the CSI snapshot controller.
 If you have Longhorn volume manifests or scripts that are still using `v1beta1` version, you must upgrade them to `v1` as well.
 
-### Add StorageClass Parameter `mkfsParams` and [`Custom mkfs.ext4 parameters`](../../references/settings/#custom-mkfsext4-parameters) Setting Deprecated
+### `Custom mkfs.ext4 parameters` Setting Removed
 
-The [`Custom mkfs.ext4 parameters`](../../references/settings/#custom-mkfsext4-parameters) will be deprecated and replaced by a new parameter `mkfsParams` as a per-StorageClass mkfs option (e.g., `-I 256 -b 4096 -O ^metadata_csum,^64bit`).
+The `Custom mkfs.ext4 parameters` setting was deprecated in Longhorn `v1.4.0` and is now removed. The per-StorageClass `mkfsParams` parameter should be used to specify mkfs options (e.g., `-I 256 -b 4096 -O ^metadata_csum,^64bit`) instead. See [Creating Longhorn Volumes with kubectl](../../volumes-and-nodes/create-volumes/#creating-longhorn-volumes-with-kubectl) for details.
 
 ### Longhorn Supports Fast Replica Rebuilding, and It Is Enabled by Default
 

--- a/content/docs/1.5.0/references/settings.md
+++ b/content/docs/1.5.0/references/settings.md
@@ -70,7 +70,6 @@ weight: 1
   - [Remove Snapshots During Filesystem Trim](#remove-snapshots-during-filesystem-trim)
 - [Deprecated](#deprecated)
   - [Disable Replica Rebuild](#disable-replica-rebuild)
-  - [Custom mkfs.ext4 parameters](#custom-mkfsext4-parameters)
   - [Allow Node Drain with the Last Healthy Replica](#allow-node-drain-with-the-last-healthy-replica)
 
 ### Customizing Default Settings
@@ -649,12 +648,6 @@ See [Trim Filesystem](../../volumes-and-nodes/trim-filesystem) for details.
 > Default: `false`
 
 This deprecated setting is replaced by the new setting `Concurrent Replica Rebuild Per Node Limit`. Once the new setting value is 0, it means rebuilding disable.
-
-#### Custom mkfs.ext4 parameters
-
-Allows setting additional filesystem creation parameters for ext4. For older host kernels it might be necessary to disable the optional ext4 metadata_csum feature by specifying `-O ^64bit,^metadata_csum`.
-
-This deprecated setting is replaced by the new setting [`mkfsParams` in the StorageClass](../../volumes-and-nodes/create-volumes/#creating-longhorn-volumes-with-kubectl) and planned removed from v1.5.0.
 
 #### Allow Node Drain with the Last Healthy Replica
 


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/4914

Document the removal of the mkfs-ext4-parameters setting in Longhorn v1.5.0.