### PR TITLE
doc: upgrade path enforcement

### DIFF
--- a/content/docs/1.5.0/deploy/upgrade/_index.md
+++ b/content/docs/1.5.0/deploy/upgrade/_index.md
@@ -9,6 +9,27 @@ Here we cover how to upgrade to the latest Longhorn from all previous releases.
 
 There are no deprecated or incompatible changes introduced in v{{< current-version >}}.
 
+# Upgrade Path Enforcement
+
+Since Longhorn v1.5.0, Longhorn only allows upgrades from supported versions. If upgrading from any unsupported version, the upgrade will fail. However, users can revert to the previous state without any service interruption or downtime.
+
+In addition, Longhorn disallows downgrading to any previous version to prevent unexpected system statuses caused by potential function incompatibility, deprecation, or removal. Please refer to the following matrix to understand the supported upgrade versions:
+
+  |  Current version |  Upgrading version |  Allow | Example |
+  |    :-:      |    :-:      |   :-:  |    :-:    |
+  |  x.y.*      |  x.(y+1).*  |   ✓    |  v1.4.2  to  v1.5.0  |
+  |  x.y.*      |  x.y.(*+n)  |   ✓    |  v1.5.0  to  v1.5.1  |
+  |  x.y[^lastMinorVersion].*      |  (x+1).y.*  |   ✓    |  v1.30.0 to  v2.0.0  |
+  |  x.(y-1).*  |  x.(y+1).*  |   X    |  v1.3.3  to  v1.5.0  |
+  |  x.(y-2).*  |  x.(y+1).*  |   X    |  v1.2.6  to  v1.5.0  |
+  |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.0  |
+  |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
+
+[^lastMinorVersion]: Longhorn only allows upgrading from a last minor version of the just previous release branch to a new major version. (1.30.* to 2.0.* given 1.30 is the last feature branch of major 1.)
+
+> **Warning**:
+> * Upgrade path enforcement is introduced in Longhorn v1.5.0, which means that downgrading from v1.5.0 to any previous version is possible. **Please note that downgrading is not supported**.
+
 # Upgrading Longhorn
 
 There are normally two steps in the upgrade process: first upgrade Longhorn manager to the latest version, then manually upgrade the Longhorn engine to the latest version using the latest Longhorn manager.

--- a/content/docs/1.5.0/deploy/upgrade/_index.md
+++ b/content/docs/1.5.0/deploy/upgrade/_index.md
@@ -25,7 +25,7 @@ In addition, Longhorn disallows downgrading to any previous version to prevent u
   |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.0  |
   |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
-[^lastMinorVersion]: Longhorn only allows upgrading from a last minor version of the just previous release branch to a new major version. (1.30.* to 2.0.* given 1.30 is the last feature branch of major 1.)
+[^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. (For example, v1.30.* is allowed to upgrade to v2.0.*, given that v1.30 is the last minor release branch before 2.0.)
 
 > **Warning**:
 > * Upgrade path enforcement is introduced in Longhorn v1.5.0, which means that downgrading from v1.5.0 to any previous version is possible. **Please note that downgrading is not supported**.

--- a/content/docs/1.5.0/deploy/upgrade/longhorn-manager.md
+++ b/content/docs/1.5.0/deploy/upgrade/longhorn-manager.md
@@ -87,6 +87,51 @@ longhorn-csi-plugin-b2zzj                             2/2     Running   0       
 
 Next, [upgrade Longhorn engine.](../upgrade-engine)
 
+### Upgrading from Unsupported Versions
+
+We only support upgrading to v{{< current-version >}} from v1.4.x. For other versions, please upgrade to v1.4.x first.
+
+If you attempt to upgrade from an unsupported version, the upgrade will fail. When encountering an upgrade failure, please consider the following scenarios to recover the state based on different upgrade methods.
+
+#### Upgrade with Kubectl
+
+When you upgrade with kubectl by running this command:
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml
+```
+
+Longhorn will block the upgrade process and provide the failure reason in the logs of the `longhorn-manager` pod.
+During the upgrade failure, the user's Longhorn system should remain intact without any impacts except `longhorn-manager` daemon set.
+
+To recover, you need to apply the manifest of the previously installed version using the following command:
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/[previous installed version]/deploy/longhorn.yaml
+```
+
+Besides, users might need to delete new components introduced by the new version manually.
+
+#### Upgrade with Helm or Rancher App Marketplace
+
+To prevent any impact caused by failed upgrades from unsupported versions, Longhorn will automatically initiate a new job (`pre-upgrade`) to verify if the upgrade path is supported before upgrading when upgrading through `Helm` or `Rancher App Marketplace`.
+
+The `pre-upgrade` job will block the upgrade process and provide the failure reason in the logs of the pod.
+During the upgrade failure, the user's Longhorn system should remain intact without any impacts.
+
+To recover, you need to run the below commands to rollback to the previously installed revision:
+
+```shell
+# get previous installed Longhorn REVISION
+helm history longhorn
+helm rollback longhorn [REVISION]
+
+# or
+helm upgrade longhorn longhorn/longhorn --namespace longhorn-system --version [previous installed version]
+```
+
+To recover, you need to upgrade to the previously installed revision at `Rancher App Marketplace` again.
+
 ### TroubleShooting
 1. Error: `"longhorn" is invalid: provisioner: Forbidden: updates to provisioner are forbidden.`
 - This means there are some modifications applied to the default storageClass and you need to clean up the old one before upgrade.


### PR DESCRIPTION
Add the upgrade path enforcement section for the `upgrade` part.
And what will happen when upgrade from v1.3.x or old versions to v1.5.0

Ref: longhorn/longhorn#5131