### PR TITLE
Slightly tweak Kubernetes minimum version wording

### DIFF
--- a/content/docs/1.5.0/deploy/important-notes/index.md
+++ b/content/docs/1.5.0/deploy/important-notes/index.md
@@ -9,7 +9,7 @@ Please see [here](https://github.com/longhorn/longhorn/releases/tag/v{{< current
 ## Notes
 
 ### Supported Kubernetes Versions
-Please ensure your Kubernetes cluster is at least v1.21 before upgrading to Longhorn v{{< current-version >}} because the supported Kubernetes version has been updated in v{{< current-version >}}.
+Please ensure your Kubernetes cluster is at least v1.21 before upgrading to Longhorn v{{< current-version >}} because this is the minimum version Longhorn v{{< current-version >}} supports.
 
 ### Recurring Jobs
 After the upgrade, the recurring job settings of volumes will be migrated to new recurring job resources, and the `RecurringJobs` field in the volume spec will be deprecated. [[doc](https://longhorn.io/docs/{{< current-version >}}/deploy/upgrade/#4-automatically-migrate-recurring-jobs)]


### PR DESCRIPTION
longhorn/longhorn#5595

It looks like we will not need to change the minimum Kubernetes version for Longhorn v1.5. Slightly tweak the wording on the website (since the supported version has not changed).