### PR TITLE
doc: Update kubectl options for `CSI external-snapshotter` version > 5.0

### DIFF
--- a/content/docs/1.4.0/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
+++ b/content/docs/1.4.0/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
@@ -26,14 +26,14 @@ You may manually install these components by executing the following steps.
 Install the Snapshot CRDs:
 1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v5.0.1/client/config/crd
 because Longhorn v{{< current-version >}} uses [CSI external-snapshotter](https://kubernetes-csi.github.io/docs/external-snapshotter.html) v5.0.1
-2. Run `kubectl create -f client/config/crd`.
+2. Run `kubectl create -k client/config/crd`.
 3. Do this once per cluster.
 
 Install the Common Snapshot Controller:
 1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v5.0.1/deploy/kubernetes/snapshot-controller
 because Longhorn v{{< current-version >}} uses [CSI external-snapshotter](https://kubernetes-csi.github.io/docs/external-snapshotter.html) v5.0.1
 2. Update the namespace to an appropriate value for your environment (e.g. `kube-system`)
-3. Run `kubectl create -f deploy/kubernetes/snapshot-controller`.
+3. Run `kubectl create -k deploy/kubernetes/snapshot-controller`.
 3. Do this once per cluster.
 > **Note:** previously, the snapshot controller YAML files were deployed into the `default` namespace by default.
 > The updated YAML files are being deployed into `kube-system` namespace by default.

--- a/content/docs/1.4.1/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
+++ b/content/docs/1.4.1/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
@@ -26,14 +26,14 @@ You may manually install these components by executing the following steps.
 Install the Snapshot CRDs:
 1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v5.0.1/client/config/crd
 because Longhorn v{{< current-version >}} uses [CSI external-snapshotter](https://kubernetes-csi.github.io/docs/external-snapshotter.html) v5.0.1
-2. Run `kubectl create -f client/config/crd`.
+2. Run `kubectl create -k client/config/crd`.
 3. Do this once per cluster.
 
 Install the Common Snapshot Controller:
 1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v5.0.1/deploy/kubernetes/snapshot-controller
 because Longhorn v{{< current-version >}} uses [CSI external-snapshotter](https://kubernetes-csi.github.io/docs/external-snapshotter.html) v5.0.1
 2. Update the namespace to an appropriate value for your environment (e.g. `kube-system`)
-3. Run `kubectl create -f deploy/kubernetes/snapshot-controller`.
+3. Run `kubectl create -k deploy/kubernetes/snapshot-controller`.
 3. Do this once per cluster.
 > **Note:** previously, the snapshot controller YAML files were deployed into the `default` namespace by default.
 > The updated YAML files are being deployed into `kube-system` namespace by default.

--- a/content/docs/1.4.2/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
+++ b/content/docs/1.4.2/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
@@ -26,14 +26,14 @@ You may manually install these components by executing the following steps.
 Install the Snapshot CRDs:
 1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v5.0.1/client/config/crd
 because Longhorn v{{< current-version >}} uses [CSI external-snapshotter](https://kubernetes-csi.github.io/docs/external-snapshotter.html) v5.0.1
-2. Run `kubectl create -f client/config/crd`.
+2. Run `kubectl create -k client/config/crd`.
 3. Do this once per cluster.
 
 Install the Common Snapshot Controller:
 1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v5.0.1/deploy/kubernetes/snapshot-controller
 because Longhorn v{{< current-version >}} uses [CSI external-snapshotter](https://kubernetes-csi.github.io/docs/external-snapshotter.html) v5.0.1
 2. Update the namespace to an appropriate value for your environment (e.g. `kube-system`)
-3. Run `kubectl create -f deploy/kubernetes/snapshot-controller`.
+3. Run `kubectl create -k deploy/kubernetes/snapshot-controller`.
 3. Do this once per cluster.
 > **Note:** previously, the snapshot controller YAML files were deployed into the `default` namespace by default.
 > The updated YAML files are being deployed into `kube-system` namespace by default.

--- a/content/docs/1.4.3/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
+++ b/content/docs/1.4.3/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
@@ -26,14 +26,14 @@ You may manually install these components by executing the following steps.
 Install the Snapshot CRDs:
 1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v5.0.1/client/config/crd
 because Longhorn v{{< current-version >}} uses [CSI external-snapshotter](https://kubernetes-csi.github.io/docs/external-snapshotter.html) v5.0.1
-2. Run `kubectl create -f client/config/crd`.
+2. Run `kubectl create -k client/config/crd`.
 3. Do this once per cluster.
 
 Install the Common Snapshot Controller:
 1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v5.0.1/deploy/kubernetes/snapshot-controller
 because Longhorn v{{< current-version >}} uses [CSI external-snapshotter](https://kubernetes-csi.github.io/docs/external-snapshotter.html) v5.0.1
 2. Update the namespace to an appropriate value for your environment (e.g. `kube-system`)
-3. Run `kubectl create -f deploy/kubernetes/snapshot-controller`.
+3. Run `kubectl create -k deploy/kubernetes/snapshot-controller`.
 3. Do this once per cluster.
 > **Note:** previously, the snapshot controller YAML files were deployed into the `default` namespace by default.
 > The updated YAML files are being deployed into `kube-system` namespace by default.

--- a/content/docs/1.5.0/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
+++ b/content/docs/1.5.0/snapshots-and-backups/csi-snapshot-support/enable-csi-snapshot-support.md
@@ -26,14 +26,14 @@ You may manually install these components by executing the following steps.
 Install the Snapshot CRDs:
 1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v6.2.1/client/config/crd
 because Longhorn v{{< current-version >}} uses [CSI external-snapshotter](https://kubernetes-csi.github.io/docs/external-snapshotter.html) v6.2.1
-2. Run `kubectl create -f client/config/crd`.
+2. Run `kubectl create -k client/config/crd`.
 3. Do this once per cluster.
 
 Install the Common Snapshot Controller:
 1. Download the files from https://github.com/kubernetes-csi/external-snapshotter/tree/v6.2.1/deploy/kubernetes/snapshot-controller
 because Longhorn v{{< current-version >}} uses [CSI external-snapshotter](https://kubernetes-csi.github.io/docs/external-snapshotter.html) v6.2.1
 2. Update the namespace to an appropriate value for your environment (e.g. `kube-system`)
-3. Run `kubectl create -f deploy/kubernetes/snapshot-controller`.
+3. Run `kubectl create -k deploy/kubernetes/snapshot-controller`.
 3. Do this once per cluster.
 > **Note:** previously, the snapshot controller YAML files were deployed into the `default` namespace by default.
 > The updated YAML files are being deployed into `kube-system` namespace by default.


### PR DESCRIPTION
In the `Enable CSI Snapshot Support on the Cluster` page, we need to install the CSI Snapshot CRD and the CSI Snapshot Controller. The version of `CSI external-snapshotte` after 5.0 uses kustomize to manage resource files, so it is necessary to modify the parameters of kubectl to operate normally

 - [v6.2.1](https://github.com/kubernetes-csi/external-snapshotter/tree/v6.2.1/client/config/crd): Used by Longhorn v1.5.0
   ![image](https://github.com/longhorn/website/assets/17548901/09142933-7206-42fd-8d98-52abc869e282)
 - [v5.0.1](https://github.com/kubernetes-csi/external-snapshotter/tree/v5.0.1/client/config/crd): Used by Longhorn v1.4.x
 ![image](https://github.com/longhorn/website/assets/17548901/561903ec-0977-401a-a555-bd3aed158eef)


https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply
![image](https://github.com/longhorn/website/assets/17548901/6e881cfd-f886-42c9-81b8-00ede73ba119)

