### PR TITLE
doc(setting): keep snapshots for the backup

### DIFF
--- a/content/docs/1.6.0/references/settings.md
+++ b/content/docs/1.6.0/references/settings.md
@@ -6,7 +6,8 @@ weight: 1
 - [Customizing Default Settings](#customizing-default-settings)
 - [General](#general)
   - [Node Drain Policy](#node-drain-policy)
-  - [Automatically Cleanup System Generated Snapshot](#automatically-cleanup-system-generated-snapshot)
+  - [Automatically Clean up System Generated Snapshot](#automatically-clean-up-system-generated-snapshot)
+  - [Automatically Clean up Outdated Snapshots of Recurring Backup Jobs](#automatically-clean-up-outdated-snapshots-of-recurring-backup-jobs)
   - [Automatically Delete Workload Pod when The Volume Is Detached Unexpectedly](#automatically-delete-workload-pod-when-the-volume-is-detached-unexpectedly)
   - [Automatic Salvage](#automatic-salvage)
   - [Concurrent Automatic Engine Upgrade Per Node Limit](#concurrent-automatic-engine-upgrade-per-node-limit)
@@ -95,11 +96,19 @@ Define the policy to use when a node with the last healthy replica of a volume i
 - `always-allow`: Longhorn will allow the drain even though the node contains the last healthy replica of a volume.
   WARNING: possible data loss if the node is removed after draining. Also possible data corruption if the last replica was running during the draining.
 
-#### Automatically Cleanup System Generated Snapshot
+#### Automatically Clean up System Generated Snapshot
 
 > Default: `true`
 
 Longhorn will generate system snapshot during replica rebuild, and if a user doesn't setup a recurring snapshot schedule, all the system generated snapshots would be left in the replica, and user has to delete them manually, this setting allow Longhorn to automatically cleanup system generated snapshot before and after replica rebuild.
+
+#### Automatically Clean up Outdated Snapshots of Recurring Backup Jobs
+
+> Default: `true`
+
+If enabled, when running a recurring backup job, Longhorn takes a new snapshot before creating the backup. Longhorn retains only the snapshot used by the last backup job even if the value of the retain parameter is not 1.
+
+If disabled, this setting ensures that the retained snapshots directly correspond to the backups on the remote backup target.
 
 #### Automatically Delete Workload Pod when The Volume Is Detached Unexpectedly
 
@@ -265,7 +274,8 @@ This information will help us gain insights how Longhorn is being used, which wi
   - Included as it is:
     - Allow Recurring Job While Volume Is Detached
     - Allow Volume Creation With Degraded Availability
-    - Automatically Cleanup System Generated Snapshot
+    - Automatically Clean up System Generated Snapshot
+    - Automatically Clean up Outdated Snapshots of Recurring Backup Jobs
     - Automatically Delete Workload Pod when The Volume Is Detached Unexpectedly
     - Automatic Salvage
     - Backing Image Cleanup Wait Interval

--- a/content/docs/1.6.0/volumes-and-nodes/volume-size.md
+++ b/content/docs/1.6.0/volumes-and-nodes/volume-size.md
@@ -133,7 +133,7 @@ Here we summarize the important things related to disk space usage we have in th
                     - The 2nd `1` means the extra snapshot created by the recurring job. Since the recurring job always creates a new snapshot then deletes the oldest snapshot when the current snapshots created by itself exceeds the retention number. Before the deletion starts, there is one extra snapshot that can take extra disk space.
                     - The 3rd `1` is the system snapshot. If the rebuilding is triggered or the expansion is issued, Longhorn will create a system snapshot before starting the operations. And this system snapshot may not be able to get cleaned up immediately.
                     - The 4th `1` is for the temporary space that may be required by snapshot deletion/purge.
-            - Users don't want snapshot at all. Neither (manually created) snapshot nor recurring job will be launched. Assume [setting _Automatically Cleanup System Generated Snapshot_](../../references/settings/#automatically-cleanup-system-generated-snapshot) is enabled, then formula would become:
+            - Users don't want snapshot at all. Neither (manually created) snapshot nor recurring job will be launched. Assume [setting _Automatically Cleanup System Generated Snapshot_](../../references/settings/#automatically-clean-up-system-generated-snapshot) is enabled, then formula would become:
 
                 ```
                 (1 + 1 + 1) x head/snapshot average actual size


### PR DESCRIPTION
Add a new global setting that allows users to keep the retain number of snapshots when the recurring job does a backup.

Ref: longhorn/longhorn#2997