### PR TITLE
Fix scheduled Backups docs for PVCs

### DIFF
--- a/content/docs/1.5.1/snapshots-and-backups/scheduling-backups-and-snapshots.md
+++ b/content/docs/1.5.1/snapshots-and-backups/scheduling-backups-and-snapshots.md
@@ -149,7 +149,7 @@ Once the PVC is labeled as the source, any recurring job labels added or removed
 kubectl -n <NAMESPACE> label pvc/<PVC-NAME> recurring-job.longhorn.io/source=enabled
 
 # Example:
-# kubectl -n default label pvc/sample recurring-job-group.longhorn.io/source=enabled
+# kubectl -n default label pvc/sample recurring-job.longhorn.io/source=enabled
 ```
 
 Add recurring job group:


### PR DESCRIPTION
The example for enabling the scheduled backups via labels references recurring-job-group.longhorn.io/source=enabled, which doesn't exist. Only recurring-job.longhorn... https://github.com/longhorn/longhorn-manager/blob/a66539f419ff3d2c68c04586b2d8df7211fca278/types/types.go#L528