### PR TITLE
6608 - Docs changes for backup target mount options.

### DIFF
--- a/content/docs/1.5.0/references/settings.md
+++ b/content/docs/1.5.0/references/settings.md
@@ -467,9 +467,12 @@ If this setting is enabled, Longhorn automatically attaches the volume and takes
 
 #### Backup Target
 
-> Example: `s3://backupbucket@us-east-1/backupstore`
+> Examples:  
+> `s3://backupbucket@us-east-1/backupstore`  
+> `nfs://longhorn-test-nfs-svc.default:/opt/backupstore`  
+> `nfs://longhorn-test-nfs-svc.default:/opt/backupstore?nfsOptions=soft,timeo=330,retrans=3`  
 
-The target used for backup. NFS and S3 are supported. See [Setting a Backup Target](../../snapshots-and-backups/backup-and-restore/set-backup-target) for details.
+Endpoint used to access a backupstore.   Longhorn supports AWS S3, Azure, GCP, CIFS and NFS.  See [Setting a Backup Target](../../snapshots-and-backups/backup-and-restore/set-backup-target) for details.
 
 #### Backup Target Credential Secret
 

--- a/content/docs/1.5.0/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/1.5.0/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -226,9 +226,9 @@ Once the secret is created and Longhorn's settings are saved, navigate to the ba
 If you don't get any error messages, try creating a backup and confirm the content is pushed out to your new bucket.
 
 ### Set up a Local Testing Backupstore
-We provides two testing purpose backupstore based on NFS server and MinIO S3 server for testing, in `./deploy/backupstores`.
+Longhorn provides sample backupstore server setups for testing purposes.  You can find samples for AWS S3 (MinIO), Azure, CIFS and NFS in the `longhorn/deploy/backupstores` folder.
 
-1. Use following command to setup a MinIO S3 server for the backupstore after `longhorn-system` was created.
+1. Set up a MinIO S3 server for the backupstore in the `longhorn-system` namespace.
 
     ```
     kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/backupstores/minio-backupstore.yaml
@@ -246,7 +246,7 @@ We provides two testing purpose backupstore based on NFS server and MinIO S3 ser
 
    The `minio-secret` yaml looks like this:
 
-    ```
+    ```yaml
     apiVersion: v1
     kind: Secret
     metadata:
@@ -281,7 +281,7 @@ To include multiple certificates, one can just concatenate the different certifi
 
 **The way to enable virtual-hosted-style access**
 1. Add a new field `VIRTUAL_HOSTED_STYLE` with value `true` to your backup target secret. e.g.:
-    ```
+    ```yaml
     apiVersion: v1
     kind: Secret
     metadata:
@@ -298,13 +298,22 @@ To include multiple certificates, one can just concatenate the different certifi
 
 ### Set up NFS Backupstore
 
-For using NFS server as backupstore, NFS server must support NFSv4.
+Ensure that the NFS server supports NFSv4 and that the target URL points to the service.
 
-The target URL should look like this:
+Example:
 
 ```
 nfs://longhorn-test-nfs-svc.default:/opt/backupstore
 ```
+
+The default mount options are `actimeo=1,soft,timeo=300,retry=2`.  To use other options, append the keyword "nfsOptions" and the options string to the target URL.  
+
+Example:  
+```
+nfs://longhorn-test-nfs-svc.default:/opt/backupstore?nfsOptions=soft,timeo=330,retrans=3  
+```
+
+Any mount options that you specify will replace, not add to, the default options.
 
 You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/deploy/backupstores/nfs-backupstore.yaml).
 
@@ -313,7 +322,7 @@ You can find an example NFS backupstore for testing purpose [here](https://githu
 ### Set up SMB/CIFS Backupstore
 
 Before configuring a SMB/CIFS backupstore, a credential secret for the backupstore can be created and deployed by
-  ```
+  ```shell
   #!/bin/bash
 
   USERNAME=${Username of SMB/CIFS Server}
@@ -344,6 +353,16 @@ Then, navigate to Longhorn UI > Setting > General > Backup
     ```
     cifs://longhorn-test-cifs-svc.default/backupstore
     ```
+
+	The default CIFS mount option is "soft".  To use other options, append the keyword "cifsOptions" and the options string to the target URL.  
+	
+	Example:
+    ```
+    cifs://longhorn-test-cifs-svc.default/backupstore?cifsOptions=rsize=65536,wsize=65536,soft
+    ```
+
+	Any mount options that you specify will replace, not add to, the default options.
+
 
 2. Set **Backup Target Credential Secret**
 

--- a/content/docs/1.5.1/references/settings.md
+++ b/content/docs/1.5.1/references/settings.md
@@ -467,9 +467,12 @@ If this setting is enabled, Longhorn automatically attaches the volume and takes
 
 #### Backup Target
 
-> Example: `s3://backupbucket@us-east-1/backupstore`
+> Examples:  
+> `s3://backupbucket@us-east-1/backupstore`  
+> `nfs://longhorn-test-nfs-svc.default:/opt/backupstore`  
+> `nfs://longhorn-test-nfs-svc.default:/opt/backupstore?nfsOptions=soft,timeo=330,retrans=3`  
 
-The target used for backup. NFS and S3 are supported. See [Setting a Backup Target](../../snapshots-and-backups/backup-and-restore/set-backup-target) for details.
+Endpoint used to access a backupstore.   Longhorn supports AWS S3, Azure, GCP, CIFS and NFS.  See [Setting a Backup Target](../../snapshots-and-backups/backup-and-restore/set-backup-target) for details.
 
 #### Backup Target Credential Secret
 

--- a/content/docs/1.5.1/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/1.5.1/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -226,9 +226,9 @@ Once the secret is created and Longhorn's settings are saved, navigate to the ba
 If you don't get any error messages, try creating a backup and confirm the content is pushed out to your new bucket.
 
 ### Set up a Local Testing Backupstore
-We provides two testing purpose backupstore based on NFS server and MinIO S3 server for testing, in `./deploy/backupstores`.
+Longhorn provides sample backupstore server setups for testing purposes.  You can find samples for AWS S3 (MinIO), Azure, CIFS and NFS in the `longhorn/deploy/backupstores` folder.
 
-1. Use following command to setup a MinIO S3 server for the backupstore after `longhorn-system` was created.
+1. Set up a MinIO S3 server for the backupstore in the `longhorn-system` namespace.
 
     ```
     kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/backupstores/minio-backupstore.yaml
@@ -246,7 +246,7 @@ We provides two testing purpose backupstore based on NFS server and MinIO S3 ser
 
    The `minio-secret` yaml looks like this:
 
-    ```
+    ```yaml
     apiVersion: v1
     kind: Secret
     metadata:
@@ -281,7 +281,7 @@ To include multiple certificates, one can just concatenate the different certifi
 
 **The way to enable virtual-hosted-style access**
 1. Add a new field `VIRTUAL_HOSTED_STYLE` with value `true` to your backup target secret. e.g.:
-    ```
+    ```yaml
     apiVersion: v1
     kind: Secret
     metadata:
@@ -298,13 +298,22 @@ To include multiple certificates, one can just concatenate the different certifi
 
 ### Set up NFS Backupstore
 
-For using NFS server as backupstore, NFS server must support NFSv4.
+Ensure that the NFS server supports NFSv4 and that the target URL points to the service.
 
-The target URL should look like this:
+Example:
 
 ```
 nfs://longhorn-test-nfs-svc.default:/opt/backupstore
 ```
+
+The default mount options are `actimeo=1,soft,timeo=300,retry=2`.  To use other options, append the keyword "nfsOptions" and the options string to the target URL.  
+
+Example:  
+```
+nfs://longhorn-test-nfs-svc.default:/opt/backupstore?nfsOptions=soft,timeo=330,retrans=3  
+```
+
+Any mount options that you specify will replace, not add to, the default options.
 
 You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/deploy/backupstores/nfs-backupstore.yaml).
 
@@ -313,7 +322,7 @@ You can find an example NFS backupstore for testing purpose [here](https://githu
 ### Set up SMB/CIFS Backupstore
 
 Before configuring a SMB/CIFS backupstore, a credential secret for the backupstore can be created and deployed by
-  ```
+  ```shell
   #!/bin/bash
 
   USERNAME=${Username of SMB/CIFS Server}
@@ -344,6 +353,16 @@ Then, navigate to Longhorn UI > Setting > General > Backup
     ```
     cifs://longhorn-test-cifs-svc.default/backupstore
     ```
+
+	The default CIFS mount option is "soft".  To use other options, append the keyword "cifsOptions" and the options string to the target URL.  
+	
+	Example:
+    ```
+    cifs://longhorn-test-cifs-svc.default/backupstore?cifsOptions=rsize=65536,wsize=65536,soft
+    ```
+
+	Any mount options that you specify will replace, not add to, the default options.
+
 
 2. Set **Backup Target Credential Secret**
 

--- a/content/docs/1.5.2/references/settings.md
+++ b/content/docs/1.5.2/references/settings.md
@@ -467,9 +467,12 @@ If this setting is enabled, Longhorn automatically attaches the volume and takes
 
 #### Backup Target
 
-> Example: `s3://backupbucket@us-east-1/backupstore`
+> Examples:  
+> `s3://backupbucket@us-east-1/backupstore`  
+> `nfs://longhorn-test-nfs-svc.default:/opt/backupstore`  
+> `nfs://longhorn-test-nfs-svc.default:/opt/backupstore?nfsOptions=soft,timeo=330,retrans=3`  
 
-The target used for backup. NFS and S3 are supported. See [Setting a Backup Target](../../snapshots-and-backups/backup-and-restore/set-backup-target) for details.
+Endpoint used to access a backupstore.   Longhorn supports AWS S3, Azure, GCP, CIFS and NFS.  See [Setting a Backup Target](../../snapshots-and-backups/backup-and-restore/set-backup-target) for details.
 
 #### Backup Target Credential Secret
 

--- a/content/docs/1.5.2/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/1.5.2/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -226,9 +226,9 @@ Once the secret is created and Longhorn's settings are saved, navigate to the ba
 If you don't get any error messages, try creating a backup and confirm the content is pushed out to your new bucket.
 
 ### Set up a Local Testing Backupstore
-We provides two testing purpose backupstore based on NFS server and MinIO S3 server for testing, in `./deploy/backupstores`.
+Longhorn provides sample backupstore server setups for testing purposes.  You can find samples for AWS S3 (MinIO), Azure, CIFS and NFS in the `longhorn/deploy/backupstores` folder.
 
-1. Use following command to setup a MinIO S3 server for the backupstore after `longhorn-system` was created.
+1. Set up a MinIO S3 server for the backupstore in the `longhorn-system` namespace.
 
     ```
     kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/backupstores/minio-backupstore.yaml
@@ -246,7 +246,7 @@ We provides two testing purpose backupstore based on NFS server and MinIO S3 ser
 
    The `minio-secret` yaml looks like this:
 
-    ```
+    ```yaml
     apiVersion: v1
     kind: Secret
     metadata:
@@ -281,7 +281,7 @@ To include multiple certificates, one can just concatenate the different certifi
 
 **The way to enable virtual-hosted-style access**
 1. Add a new field `VIRTUAL_HOSTED_STYLE` with value `true` to your backup target secret. e.g.:
-    ```
+    ```yaml
     apiVersion: v1
     kind: Secret
     metadata:
@@ -298,13 +298,22 @@ To include multiple certificates, one can just concatenate the different certifi
 
 ### Set up NFS Backupstore
 
-For using NFS server as backupstore, NFS server must support NFSv4.
+Ensure that the NFS server supports NFSv4 and that the target URL points to the service.
 
-The target URL should look like this:
+Example:
 
 ```
 nfs://longhorn-test-nfs-svc.default:/opt/backupstore
 ```
+
+The default mount options are `actimeo=1,soft,timeo=300,retry=2`.  To use other options, append the keyword "nfsOptions" and the options string to the target URL.  
+
+Example:  
+```
+nfs://longhorn-test-nfs-svc.default:/opt/backupstore?nfsOptions=soft,timeo=330,retrans=3  
+```
+
+Any mount options that you specify will replace, not add to, the default options.
 
 You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/deploy/backupstores/nfs-backupstore.yaml).
 
@@ -313,7 +322,7 @@ You can find an example NFS backupstore for testing purpose [here](https://githu
 ### Set up SMB/CIFS Backupstore
 
 Before configuring a SMB/CIFS backupstore, a credential secret for the backupstore can be created and deployed by
-  ```
+  ```shell
   #!/bin/bash
 
   USERNAME=${Username of SMB/CIFS Server}
@@ -344,6 +353,16 @@ Then, navigate to Longhorn UI > Setting > General > Backup
     ```
     cifs://longhorn-test-cifs-svc.default/backupstore
     ```
+
+	The default CIFS mount option is "soft".  To use other options, append the keyword "cifsOptions" and the options string to the target URL.  
+	
+	Example:
+    ```
+    cifs://longhorn-test-cifs-svc.default/backupstore?cifsOptions=rsize=65536,wsize=65536,soft
+    ```
+
+	Any mount options that you specify will replace, not add to, the default options.
+
 
 2. Set **Backup Target Credential Secret**
 

--- a/content/docs/1.5.3/references/settings.md
+++ b/content/docs/1.5.3/references/settings.md
@@ -467,9 +467,12 @@ If this setting is enabled, Longhorn automatically attaches the volume and takes
 
 #### Backup Target
 
-> Example: `s3://backupbucket@us-east-1/backupstore`
+> Examples:  
+> `s3://backupbucket@us-east-1/backupstore`  
+> `nfs://longhorn-test-nfs-svc.default:/opt/backupstore`  
+> `nfs://longhorn-test-nfs-svc.default:/opt/backupstore?nfsOptions=soft,timeo=330,retrans=3`  
 
-The target used for backup. NFS and S3 are supported. See [Setting a Backup Target](../../snapshots-and-backups/backup-and-restore/set-backup-target) for details.
+Endpoint used to access a backupstore.   Longhorn supports AWS S3, Azure, GCP, CIFS and NFS.  See [Setting a Backup Target](../../snapshots-and-backups/backup-and-restore/set-backup-target) for details.
 
 #### Backup Target Credential Secret
 

--- a/content/docs/1.5.3/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/1.5.3/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -226,9 +226,9 @@ Once the secret is created and Longhorn's settings are saved, navigate to the ba
 If you don't get any error messages, try creating a backup and confirm the content is pushed out to your new bucket.
 
 ### Set up a Local Testing Backupstore
-We provides two testing purpose backupstore based on NFS server and MinIO S3 server for testing, in `./deploy/backupstores`.
+Longhorn provides sample backupstore server setups for testing purposes.  You can find samples for AWS S3 (MinIO), Azure, CIFS and NFS in the `longhorn/deploy/backupstores` folder.
 
-1. Use following command to setup a MinIO S3 server for the backupstore after `longhorn-system` was created.
+1. Set up a MinIO S3 server for the backupstore in the `longhorn-system` namespace.
 
     ```
     kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/backupstores/minio-backupstore.yaml
@@ -246,7 +246,7 @@ We provides two testing purpose backupstore based on NFS server and MinIO S3 ser
 
    The `minio-secret` yaml looks like this:
 
-    ```
+    ```yaml
     apiVersion: v1
     kind: Secret
     metadata:
@@ -281,7 +281,7 @@ To include multiple certificates, one can just concatenate the different certifi
 
 **The way to enable virtual-hosted-style access**
 1. Add a new field `VIRTUAL_HOSTED_STYLE` with value `true` to your backup target secret. e.g.:
-    ```
+    ```yaml
     apiVersion: v1
     kind: Secret
     metadata:
@@ -298,13 +298,22 @@ To include multiple certificates, one can just concatenate the different certifi
 
 ### Set up NFS Backupstore
 
-For using NFS server as backupstore, NFS server must support NFSv4.
+Ensure that the NFS server supports NFSv4 and that the target URL points to the service.
 
-The target URL should look like this:
+Example:
 
 ```
 nfs://longhorn-test-nfs-svc.default:/opt/backupstore
 ```
+
+The default mount options are `actimeo=1,soft,timeo=300,retry=2`.  To use other options, append the keyword "nfsOptions" and the options string to the target URL.  
+
+Example:  
+```
+nfs://longhorn-test-nfs-svc.default:/opt/backupstore?nfsOptions=soft,timeo=330,retrans=3  
+```
+
+Any mount options that you specify will replace, not add to, the default options.
 
 You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/deploy/backupstores/nfs-backupstore.yaml).
 
@@ -313,7 +322,7 @@ You can find an example NFS backupstore for testing purpose [here](https://githu
 ### Set up SMB/CIFS Backupstore
 
 Before configuring a SMB/CIFS backupstore, a credential secret for the backupstore can be created and deployed by
-  ```
+  ```shell
   #!/bin/bash
 
   USERNAME=${Username of SMB/CIFS Server}
@@ -344,6 +353,16 @@ Then, navigate to Longhorn UI > Setting > General > Backup
     ```
     cifs://longhorn-test-cifs-svc.default/backupstore
     ```
+
+	The default CIFS mount option is "soft".  To use other options, append the keyword "cifsOptions" and the options string to the target URL.  
+	
+	Example:
+    ```
+    cifs://longhorn-test-cifs-svc.default/backupstore?cifsOptions=rsize=65536,wsize=65536,soft
+    ```
+
+	Any mount options that you specify will replace, not add to, the default options.
+
 
 2. Set **Backup Target Credential Secret**
 

--- a/content/docs/1.5.4/references/settings.md
+++ b/content/docs/1.5.4/references/settings.md
@@ -467,9 +467,12 @@ If this setting is enabled, Longhorn automatically attaches the volume and takes
 
 #### Backup Target
 
-> Example: `s3://backupbucket@us-east-1/backupstore`
+> Examples:  
+> `s3://backupbucket@us-east-1/backupstore`  
+> `nfs://longhorn-test-nfs-svc.default:/opt/backupstore`  
+> `nfs://longhorn-test-nfs-svc.default:/opt/backupstore?nfsOptions=soft,timeo=330,retrans=3`  
 
-The target used for backup. NFS and S3 are supported. See [Setting a Backup Target](../../snapshots-and-backups/backup-and-restore/set-backup-target) for details.
+Endpoint used to access a backupstore.   Longhorn supports AWS S3, Azure, GCP, CIFS and NFS.  See [Setting a Backup Target](../../snapshots-and-backups/backup-and-restore/set-backup-target) for details.
 
 #### Backup Target Credential Secret
 

--- a/content/docs/1.5.4/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/1.5.4/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -226,9 +226,9 @@ Once the secret is created and Longhorn's settings are saved, navigate to the ba
 If you don't get any error messages, try creating a backup and confirm the content is pushed out to your new bucket.
 
 ### Set up a Local Testing Backupstore
-We provides two testing purpose backupstore based on NFS server and MinIO S3 server for testing, in `./deploy/backupstores`.
+Longhorn provides sample backupstore server setups for testing purposes.  You can find samples for AWS S3 (MinIO), Azure, CIFS and NFS in the `longhorn/deploy/backupstores` folder.
 
-1. Use following command to setup a MinIO S3 server for the backupstore after `longhorn-system` was created.
+1. Set up a MinIO S3 server for the backupstore in the `longhorn-system` namespace.
 
     ```
     kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/backupstores/minio-backupstore.yaml
@@ -246,7 +246,7 @@ We provides two testing purpose backupstore based on NFS server and MinIO S3 ser
 
    The `minio-secret` yaml looks like this:
 
-    ```
+    ```yaml
     apiVersion: v1
     kind: Secret
     metadata:
@@ -281,7 +281,7 @@ To include multiple certificates, one can just concatenate the different certifi
 
 **The way to enable virtual-hosted-style access**
 1. Add a new field `VIRTUAL_HOSTED_STYLE` with value `true` to your backup target secret. e.g.:
-    ```
+    ```yaml
     apiVersion: v1
     kind: Secret
     metadata:
@@ -298,13 +298,22 @@ To include multiple certificates, one can just concatenate the different certifi
 
 ### Set up NFS Backupstore
 
-For using NFS server as backupstore, NFS server must support NFSv4.
+Ensure that the NFS server supports NFSv4 and that the target URL points to the service.
 
-The target URL should look like this:
+Example:
 
 ```
 nfs://longhorn-test-nfs-svc.default:/opt/backupstore
 ```
+
+The default mount options are `actimeo=1,soft,timeo=300,retry=2`.  To use other options, append the keyword "nfsOptions" and the options string to the target URL.  
+
+Example:  
+```
+nfs://longhorn-test-nfs-svc.default:/opt/backupstore?nfsOptions=soft,timeo=330,retrans=3  
+```
+
+Any mount options that you specify will replace, not add to, the default options.
 
 You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/deploy/backupstores/nfs-backupstore.yaml).
 
@@ -313,7 +322,7 @@ You can find an example NFS backupstore for testing purpose [here](https://githu
 ### Set up SMB/CIFS Backupstore
 
 Before configuring a SMB/CIFS backupstore, a credential secret for the backupstore can be created and deployed by
-  ```
+  ```shell
   #!/bin/bash
 
   USERNAME=${Username of SMB/CIFS Server}
@@ -344,6 +353,16 @@ Then, navigate to Longhorn UI > Setting > General > Backup
     ```
     cifs://longhorn-test-cifs-svc.default/backupstore
     ```
+
+	The default CIFS mount option is "soft".  To use other options, append the keyword "cifsOptions" and the options string to the target URL.  
+	
+	Example:
+    ```
+    cifs://longhorn-test-cifs-svc.default/backupstore?cifsOptions=rsize=65536,wsize=65536,soft
+    ```
+
+	Any mount options that you specify will replace, not add to, the default options.
+
 
 2. Set **Backup Target Credential Secret**
 

--- a/content/docs/1.6.0/references/settings.md
+++ b/content/docs/1.6.0/references/settings.md
@@ -481,9 +481,12 @@ If this setting is enabled, Longhorn automatically attaches the volume and takes
 
 #### Backup Target
 
-> Example: `s3://backupbucket@us-east-1/backupstore`
+> Examples:  
+> `s3://backupbucket@us-east-1/backupstore`  
+> `nfs://longhorn-test-nfs-svc.default:/opt/backupstore`  
+> `nfs://longhorn-test-nfs-svc.default:/opt/backupstore?nfsOptions=soft,timeo=330,retrans=3`  
 
-The target used for backup. NFS and S3 are supported. See [Setting a Backup Target](../../snapshots-and-backups/backup-and-restore/set-backup-target) for details.
+Endpoint used to access a backupstore.   Longhorn supports AWS S3, Azure, GCP, CIFS and NFS.  See [Setting a Backup Target](../../snapshots-and-backups/backup-and-restore/set-backup-target) for details.
 
 #### Backup Target Credential Secret
 

--- a/content/docs/1.6.0/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/1.6.0/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -226,9 +226,9 @@ Once the secret is created and Longhorn's settings are saved, navigate to the ba
 If you don't get any error messages, try creating a backup and confirm the content is pushed out to your new bucket.
 
 ### Set up a Local Testing Backupstore
-We provides two testing purpose backupstore based on NFS server and MinIO S3 server for testing, in `./deploy/backupstores`.
+Longhorn provides sample backupstore server setups for testing purposes.  You can find samples for AWS S3 (MinIO), Azure, CIFS and NFS in the `longhorn/deploy/backupstores` folder.
 
-1. Use following command to setup a MinIO S3 server for the backupstore after `longhorn-system` was created.
+1. Set up a MinIO S3 server for the backupstore in the `longhorn-system` namespace.
 
     ```
     kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/backupstores/minio-backupstore.yaml
@@ -246,7 +246,7 @@ We provides two testing purpose backupstore based on NFS server and MinIO S3 ser
 
    The `minio-secret` yaml looks like this:
 
-    ```
+    ```yaml
     apiVersion: v1
     kind: Secret
     metadata:
@@ -281,7 +281,7 @@ To include multiple certificates, one can just concatenate the different certifi
 
 **The way to enable virtual-hosted-style access**
 1. Add a new field `VIRTUAL_HOSTED_STYLE` with value `true` to your backup target secret. e.g.:
-    ```
+    ```yaml
     apiVersion: v1
     kind: Secret
     metadata:
@@ -298,13 +298,22 @@ To include multiple certificates, one can just concatenate the different certifi
 
 ### Set up NFS Backupstore
 
-For using NFS server as backupstore, NFS server must support NFSv4.
+Ensure that the NFS server supports NFSv4 and that the target URL points to the service.
 
-The target URL should look like this:
+Example:
 
 ```
 nfs://longhorn-test-nfs-svc.default:/opt/backupstore
 ```
+
+The default mount options are `actimeo=1,soft,timeo=300,retry=2`.  To use other options, append the keyword "nfsOptions" and the options string to the target URL.  
+
+Example:  
+```
+nfs://longhorn-test-nfs-svc.default:/opt/backupstore?nfsOptions=soft,timeo=330,retrans=3  
+```
+
+Any mount options that you specify will replace, not add to, the default options.
 
 You can find an example NFS backupstore for testing purpose [here](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/deploy/backupstores/nfs-backupstore.yaml).
 
@@ -313,7 +322,7 @@ You can find an example NFS backupstore for testing purpose [here](https://githu
 ### Set up SMB/CIFS Backupstore
 
 Before configuring a SMB/CIFS backupstore, a credential secret for the backupstore can be created and deployed by
-  ```
+  ```shell
   #!/bin/bash
 
   USERNAME=${Username of SMB/CIFS Server}
@@ -344,6 +353,16 @@ Then, navigate to Longhorn UI > Setting > General > Backup
     ```
     cifs://longhorn-test-cifs-svc.default/backupstore
     ```
+
+	The default CIFS mount option is "soft".  To use other options, append the keyword "cifsOptions" and the options string to the target URL.  
+	
+	Example:
+    ```
+    cifs://longhorn-test-cifs-svc.default/backupstore?cifsOptions=rsize=65536,wsize=65536,soft
+    ```
+
+	Any mount options that you specify will replace, not add to, the default options.
+
 
 2. Set **Backup Target Credential Secret**
 


### PR DESCRIPTION
This PR has the documentation changes for longhorn/longhorn#6608, enable mount options for NFS and CIFS backup targets.
First version is for review on contents.  Changes will need to be backported where the functionality has.
I will squash all the commits when the content is approved for all releases.