### PR TITLE
doc: remove duplicated troubleshooting section from uninstall topic

### DIFF
--- a/content/docs/1.4.0/deploy/uninstall/_index.md
+++ b/content/docs/1.4.0/deploy/uninstall/_index.md
@@ -126,15 +126,5 @@ for crd in $(kubectl get crd -o jsonpath={.items[*].metadata.name} | tr ' ' '\n'
 done
 ```
 
-#### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
-
-Check if volume plugin directory has been set correctly. This is automatically detected unless user explicitly set it. Note: The FlexVolume plugin is deprecated as of Longhorn v0.8.0 and should no longer be used.
-
-By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
-
-Some vendors choose to change the directory for various reasons. For example, GKE uses `/home/kubernetes/flexvolume` instead.
-
-User can find the correct directory by running `ps aux|grep kubelet` on the host and check the `--volume-plugin-dir` parameter. If there is none, the default `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` will be used.
-
 ---
 Please see [link](https://github.com/longhorn/longhorn) for more information.

--- a/content/docs/1.4.1/deploy/uninstall/_index.md
+++ b/content/docs/1.4.1/deploy/uninstall/_index.md
@@ -126,15 +126,5 @@ for crd in $(kubectl get crd -o jsonpath={.items[*].metadata.name} | tr ' ' '\n'
 done
 ```
 
-#### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
-
-Check if volume plugin directory has been set correctly. This is automatically detected unless user explicitly set it. Note: The FlexVolume plugin is deprecated as of Longhorn v0.8.0 and should no longer be used.
-
-By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
-
-Some vendors choose to change the directory for various reasons. For example, GKE uses `/home/kubernetes/flexvolume` instead.
-
-User can find the correct directory by running `ps aux|grep kubelet` on the host and check the `--volume-plugin-dir` parameter. If there is none, the default `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` will be used.
-
 ---
 Please see [link](https://github.com/longhorn/longhorn) for more information.

--- a/content/docs/1.4.2/deploy/uninstall/_index.md
+++ b/content/docs/1.4.2/deploy/uninstall/_index.md
@@ -126,15 +126,5 @@ for crd in $(kubectl get crd -o jsonpath={.items[*].metadata.name} | tr ' ' '\n'
 done
 ```
 
-#### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
-
-Check if volume plugin directory has been set correctly. This is automatically detected unless user explicitly set it. Note: The FlexVolume plugin is deprecated as of Longhorn v0.8.0 and should no longer be used.
-
-By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
-
-Some vendors choose to change the directory for various reasons. For example, GKE uses `/home/kubernetes/flexvolume` instead.
-
-User can find the correct directory by running `ps aux|grep kubelet` on the host and check the `--volume-plugin-dir` parameter. If there is none, the default `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` will be used.
-
 ---
 Please see [link](https://github.com/longhorn/longhorn) for more information.

--- a/content/docs/1.4.3/deploy/uninstall/_index.md
+++ b/content/docs/1.4.3/deploy/uninstall/_index.md
@@ -126,15 +126,5 @@ for crd in $(kubectl get crd -o jsonpath={.items[*].metadata.name} | tr ' ' '\n'
 done
 ```
 
-#### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
-
-Check if volume plugin directory has been set correctly. This is automatically detected unless user explicitly set it. Note: The FlexVolume plugin is deprecated as of Longhorn v0.8.0 and should no longer be used.
-
-By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
-
-Some vendors choose to change the directory for various reasons. For example, GKE uses `/home/kubernetes/flexvolume` instead.
-
-User can find the correct directory by running `ps aux|grep kubelet` on the host and check the `--volume-plugin-dir` parameter. If there is none, the default `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` will be used.
-
 ---
 Please see [link](https://github.com/longhorn/longhorn) for more information.

--- a/content/docs/1.4.4/deploy/uninstall/_index.md
+++ b/content/docs/1.4.4/deploy/uninstall/_index.md
@@ -126,15 +126,5 @@ for crd in $(kubectl get crd -o jsonpath={.items[*].metadata.name} | tr ' ' '\n'
 done
 ```
 
-#### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
-
-Check if volume plugin directory has been set correctly. This is automatically detected unless user explicitly set it. Note: The FlexVolume plugin is deprecated as of Longhorn v0.8.0 and should no longer be used.
-
-By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
-
-Some vendors choose to change the directory for various reasons. For example, GKE uses `/home/kubernetes/flexvolume` instead.
-
-User can find the correct directory by running `ps aux|grep kubelet` on the host and check the `--volume-plugin-dir` parameter. If there is none, the default `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` will be used.
-
 ---
 Please see [link](https://github.com/longhorn/longhorn) for more information.

--- a/content/docs/1.4.5/deploy/uninstall/_index.md
+++ b/content/docs/1.4.5/deploy/uninstall/_index.md
@@ -126,15 +126,5 @@ for crd in $(kubectl get crd -o jsonpath={.items[*].metadata.name} | tr ' ' '\n'
 done
 ```
 
-#### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
-
-Check if volume plugin directory has been set correctly. This is automatically detected unless user explicitly set it. Note: The FlexVolume plugin is deprecated as of Longhorn v0.8.0 and should no longer be used.
-
-By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
-
-Some vendors choose to change the directory for various reasons. For example, GKE uses `/home/kubernetes/flexvolume` instead.
-
-User can find the correct directory by running `ps aux|grep kubelet` on the host and check the `--volume-plugin-dir` parameter. If there is none, the default `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` will be used.
-
 ---
 Please see [link](https://github.com/longhorn/longhorn) for more information.

--- a/content/docs/1.5.0/deploy/uninstall/_index.md
+++ b/content/docs/1.5.0/deploy/uninstall/_index.md
@@ -126,15 +126,5 @@ for crd in $(kubectl get crd -o jsonpath={.items[*].metadata.name} | tr ' ' '\n'
 done
 ```
 
-#### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
-
-Check if volume plugin directory has been set correctly. This is automatically detected unless user explicitly set it. Note: The FlexVolume plugin is deprecated as of Longhorn v0.8.0 and should no longer be used.
-
-By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
-
-Some vendors choose to change the directory for various reasons. For example, GKE uses `/home/kubernetes/flexvolume` instead.
-
-User can find the correct directory by running `ps aux|grep kubelet` on the host and check the `--volume-plugin-dir` parameter. If there is none, the default `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` will be used.
-
 ---
 Please see [link](https://github.com/longhorn/longhorn) for more information.

--- a/content/docs/1.5.1/deploy/uninstall/_index.md
+++ b/content/docs/1.5.1/deploy/uninstall/_index.md
@@ -126,15 +126,5 @@ for crd in $(kubectl get crd -o jsonpath={.items[*].metadata.name} | tr ' ' '\n'
 done
 ```
 
-#### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
-
-Check if volume plugin directory has been set correctly. This is automatically detected unless user explicitly set it. Note: The FlexVolume plugin is deprecated as of Longhorn v0.8.0 and should no longer be used.
-
-By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
-
-Some vendors choose to change the directory for various reasons. For example, GKE uses `/home/kubernetes/flexvolume` instead.
-
-User can find the correct directory by running `ps aux|grep kubelet` on the host and check the `--volume-plugin-dir` parameter. If there is none, the default `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` will be used.
-
 ---
 Please see [link](https://github.com/longhorn/longhorn) for more information.

--- a/content/docs/1.5.2/deploy/uninstall/_index.md
+++ b/content/docs/1.5.2/deploy/uninstall/_index.md
@@ -126,15 +126,5 @@ for crd in $(kubectl get crd -o jsonpath={.items[*].metadata.name} | tr ' ' '\n'
 done
 ```
 
-#### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
-
-Check if volume plugin directory has been set correctly. This is automatically detected unless user explicitly set it. Note: The FlexVolume plugin is deprecated as of Longhorn v0.8.0 and should no longer be used.
-
-By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
-
-Some vendors choose to change the directory for various reasons. For example, GKE uses `/home/kubernetes/flexvolume` instead.
-
-User can find the correct directory by running `ps aux|grep kubelet` on the host and check the `--volume-plugin-dir` parameter. If there is none, the default `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` will be used.
-
 ---
 Please see [link](https://github.com/longhorn/longhorn) for more information.

--- a/content/docs/1.5.3/deploy/uninstall/_index.md
+++ b/content/docs/1.5.3/deploy/uninstall/_index.md
@@ -126,15 +126,5 @@ for crd in $(kubectl get crd -o jsonpath={.items[*].metadata.name} | tr ' ' '\n'
 done
 ```
 
-#### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
-
-Check if volume plugin directory has been set correctly. This is automatically detected unless user explicitly set it. Note: The FlexVolume plugin is deprecated as of Longhorn v0.8.0 and should no longer be used.
-
-By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
-
-Some vendors choose to change the directory for various reasons. For example, GKE uses `/home/kubernetes/flexvolume` instead.
-
-User can find the correct directory by running `ps aux|grep kubelet` on the host and check the `--volume-plugin-dir` parameter. If there is none, the default `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` will be used.
-
 ---
 Please see [link](https://github.com/longhorn/longhorn) for more information.

--- a/content/docs/1.5.4/deploy/uninstall/_index.md
+++ b/content/docs/1.5.4/deploy/uninstall/_index.md
@@ -126,15 +126,5 @@ for crd in $(kubectl get crd -o jsonpath={.items[*].metadata.name} | tr ' ' '\n'
 done
 ```
 
-#### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
-
-Check if volume plugin directory has been set correctly. This is automatically detected unless user explicitly set it. Note: The FlexVolume plugin is deprecated as of Longhorn v0.8.0 and should no longer be used.
-
-By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
-
-Some vendors choose to change the directory for various reasons. For example, GKE uses `/home/kubernetes/flexvolume` instead.
-
-User can find the correct directory by running `ps aux|grep kubelet` on the host and check the `--volume-plugin-dir` parameter. If there is none, the default `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` will be used.
-
 ---
 Please see [link](https://github.com/longhorn/longhorn) for more information.

--- a/content/docs/1.6.0/deploy/uninstall/_index.md
+++ b/content/docs/1.6.0/deploy/uninstall/_index.md
@@ -126,15 +126,5 @@ for crd in $(kubectl get crd -o jsonpath={.items[*].metadata.name} | tr ' ' '\n'
 done
 ```
 
-#### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
-
-Check if volume plugin directory has been set correctly. This is automatically detected unless user explicitly set it. Note: The FlexVolume plugin is deprecated as of Longhorn v0.8.0 and should no longer be used.
-
-By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
-
-Some vendors choose to change the directory for various reasons. For example, GKE uses `/home/kubernetes/flexvolume` instead.
-
-User can find the correct directory by running `ps aux|grep kubelet` on the host and check the `--volume-plugin-dir` parameter. If there is none, the default `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/` will be used.
-
 ---
 Please see [link](https://github.com/longhorn/longhorn) for more information.


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/7603

The troubleshooting note about attach/detach is not on topic for uninstall, and duplicates a section in the advanced-resource troubleshooting page.