### PR TITLE
Update the description of v2-data-engine setting

### DIFF
--- a/content/docs/1.6.0/references/settings.md
+++ b/content/docs/1.6.0/references/settings.md
@@ -454,8 +454,6 @@ This allows users to activate the v2 data engine based on SPDK. Currently, it is
 >
 > - DO NOT CHANGE THIS SETTING WITH ATTACHED VOLUMES. Longhorn will block this setting update when there are attached volumes.
 >
-> - When applying the setting, Longhorn will restart all instance-manager pods.
->
 > - When the V2 Data Engine is enabled, each instance-manager pod utilizes 1 CPU core. This high CPU usage is attributed to the spdk_tgt process running within each instance-manager pod. The spdk_tgt process is responsible for handling input/output (IO) operations and requires intensive polling. As a result, it consumes 100% of a dedicated CPU core to efficiently manage and process the IO requests, ensuring optimal performance and responsiveness for storage operations.
 
 #### V2 Data Engine Huge Page Limit


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/7655

#### What this PR does / why we need it:

v1 and v2 date engines are separate, so the warning `When applying the setting, Longhorn will restart all instance-manager pods.` is not required.

#### Special notes for your reviewer:

#### Additional documentation or context
