### PR TITLE
Improve 'Upgrade Path Enforcement' content

### DIFF
--- a/content/docs/1.5.0/deploy/upgrade/_index.md
+++ b/content/docs/1.5.0/deploy/upgrade/_index.md
@@ -11,11 +11,11 @@ There are no deprecated or incompatible changes introduced in v{{< current-versi
 
 # Upgrade Path Enforcement
 
-Since Longhorn v1.5.0, Longhorn only allows upgrades from supported versions. If upgrading from any unsupported version, the upgrade will fail. However, users can revert to the previous state without any service interruption or downtime.
+Starting with v1.5.0, Longhorn only allows upgrades from supported versions. When you attempt to upgrade from an unsupported version, the upgrade automatically fails but you can revert to the previously installed version without any service interruption or downtime.
 
-In addition, Longhorn disallows downgrading to any previous version to prevent unexpected system statuses caused by potential function incompatibility, deprecation, or removal. Please refer to the following matrix to understand the supported upgrade versions and there is an example for each upgrade path:
+The following table outlines the supported upgrade paths.
 
-  |  Current version |  Upgrading version |  Allow | Example |
+  |  Current version |  Target version |  Allowed | Example |
   |    :-:      |    :-:      |   :-:  |    :-:    |
   |  x.y.*      |  x.(y+1).*  |   ✓    |  v1.4.2  to  v1.5.0  |
   |  x.y.*      |  x.y.(*+n)  |   ✓    |  v1.5.0  to  v1.5.1  |
@@ -25,10 +25,10 @@ In addition, Longhorn disallows downgrading to any previous version to prevent u
   |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.0  |
   |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
-[^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. (For example, v1.30.* is allowed to upgrade to v2.0.*, given that v1.30 is the last minor release branch before 2.0.)
+[^lastMinorVersion]: Longhorn only allows upgrades from a patch version of the last minor release before the new major version. For example, you can upgrade from v1.3.* to v2.0.* because v1.3.0 is the last minor release before v2.0.
 
-> **Warning**:
-> * Upgrade path enforcement is introduced in Longhorn v1.5.0, which means that downgrading from v1.5.0 to any previous version is possible. **Please note that downgrading is not supported**.
+> **Important:**
+> If necessary, you can downgrade from v1.5.0 to an earlier version.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.5.0/deploy/upgrade/_index.md
+++ b/content/docs/1.5.0/deploy/upgrade/_index.md
@@ -9,13 +9,19 @@ Here we cover how to upgrade to the latest Longhorn from all previous releases.
 
 There are no deprecated or incompatible changes introduced in v{{< current-version >}}.
 
-# Upgrade Path Enforcement
+# Upgrade Path Enforcement and Downgrade Prevention
 
-Starting with v1.5.0, Longhorn only allows upgrades from supported versions. When you attempt to upgrade from an unsupported version, the upgrade automatically fails but you can revert to the previously installed version without any service interruption or downtime.
+Starting with v1.5.0, Longhorn only allows upgrades from supported versions. When you attempt to upgrade from an unsupported version, the operation automatically fails but you can revert to the previously installed version without any service interruption or downtime.
+
+Moreover, Longhorn does not support downgrades to earlier versions. This restriction helps prevent unexpected system behavior and issues associated with function incompatibility, deprecation, or removal. 
+
+> **Warning:**
+> The Downgrade Prevention feature was introduced in v1.5.0 so Longhorn is unable to prevent downgrade attempts in older versions.
+However, downgrading is completely unsupported and is therefore not recommended.
 
 The following table outlines the supported upgrade paths.
 
-  |  Current version |  Target version |  Allowed | Example |
+  |  Current version |  Target version |  Supported | Example |
   |    :-:      |    :-:      |   :-:  |    :-:    |
   |  x.y.*      |  x.(y+1).*  |   ✓    |  v1.4.2  to  v1.5.0  |
   |  x.y.*      |  x.y.(*+n)  |   ✓    |  v1.5.0  to  v1.5.1  |
@@ -25,10 +31,7 @@ The following table outlines the supported upgrade paths.
   |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.0  |
   |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
-[^lastMinorVersion]: Longhorn only allows upgrades from a patch version of the last minor release before the new major version. For example, you can upgrade from v1.3.* to v2.0.* because v1.3.0 is the last minor release before v2.0.
-
-> **Important:**
-> If necessary, you can downgrade from v1.5.0 to an earlier version.
+[^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. For example, if v1.3.0 is the last minor version before v2.0, you can upgrade from any patch version of v1.3.0 to any patch version of v2.0.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.6.0/deploy/important-notes/index.md
+++ b/content/docs/1.6.0/deploy/important-notes/index.md
@@ -117,7 +117,7 @@ When upgrading through Helm, a component compatibility check is automatically pe
 If you installed Longhorn using the manifests, engine upgrades are enforced by the Longhorn Manager. Attempts to upgrade Longhorn Manager may cause unsuccessful pod launches and generate corresponding error logs, although it poses no harm. If you encounter such errors, you must revert to the previous Longhorn version and then upgrade the engines that are using the incompatible engine images before the next upgrade.
 
 > **Warning:**
-> Whenever engine upgrade enforcement causes upgrade failure, Longhorn allows you to revert to the previous version because Longhorn Manager will block the entire upgrade. However, Longhorn prohibits downgrading when an upgrade is successful. For more information, see [Upgrade Path Enforcement](../../deploy/upgrade/#upgrade-path-enforcement).
+> Whenever engine upgrade enforcement causes upgrade failure, Longhorn allows you to revert to the previous version because Longhorn Manager will block the entire upgrade. However, Longhorn prohibits downgrading when an upgrade is successful. For more information, see [Upgrade Path Enforcement](../../deploy/upgrade/#upgrade-path-enforcement-and-downgrade-prevention).
 
 You can determine the versions of engine images that are currently in use with the following script:
 ```bash

--- a/content/docs/1.6.0/deploy/upgrade/_index.md
+++ b/content/docs/1.6.0/deploy/upgrade/_index.md
@@ -9,13 +9,20 @@ Here we cover how to upgrade to the latest Longhorn from all previous releases.
 
 There are no deprecated or incompatible changes introduced in v{{< current-version >}}.
 
-# Upgrade Path Enforcement
+# Upgrade Path Enforcement and Downgrade Prevention  
 
-Starting with v1.5.0, Longhorn only allows upgrades from supported versions. When you attempt to upgrade from an unsupported version, the upgrade automatically fails but you can revert to the previously installed version without any service interruption or downtime.
+Starting with v1.5.0, Longhorn only allows upgrades from supported versions. When you attempt to upgrade from an unsupported version, the operation automatically fails but you can revert to the previously installed version without any service interruption or downtime.  
+
+Moreover, Longhorn does not support downgrades to earlier versions. This restriction helps prevent unexpected system behavior and issues associated with function incompatibility, deprecation, or removal.  
+
+> **Warning**:
+> - Once you successfully upgrade to v1.6.0, you will not be allowed to revert to the previously installed version. 
+> - The Downgrade Prevention feature was introduced in v1.5.0 so Longhorn is unable to prevent downgrade attempts in older versions.
+However, downgrading is completely unsupported and is therefore not recommended.
 
 The following table outlines the supported upgrade paths.
 
-  |  Current version |  Target version |  Allowed | Example |
+  |  Current version |  Target version |  Supported | Example |
   |    :-:      |    :-:      |   :-:  |    :-:    |
   |  x.y.*      |  x.(y+1).*  |   ✓    |  v1.4.2  to  v1.5.1  |
   |  x.y.*      |  x.y.(*+n)  |   ✓    |  v1.5.0  to  v1.5.1  |
@@ -25,10 +32,7 @@ The following table outlines the supported upgrade paths.
   |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.1  |
   |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
-[^lastMinorVersion]: Longhorn only allows upgrades from a patch version of the last minor release before the new major version. For example, you can upgrade from v1.3.* to v2.0.* because v1.3.0 is the last minor release before v2.0.
-
-> **Important**:
-> When you successfully upgrade to v1.6.0, you will not be allowed to revert to the previously installed version. This restriction helps prevent unexpected system behavior and issues caused by function incompatibility, deprecation, or removal.
+[^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. For example, if v1.3.0 is the last minor version before v2.0, you can upgrade from any patch version of v1.3.0 to any patch version of v2.0.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.6.0/deploy/upgrade/_index.md
+++ b/content/docs/1.6.0/deploy/upgrade/_index.md
@@ -11,11 +11,11 @@ There are no deprecated or incompatible changes introduced in v{{< current-versi
 
 # Upgrade Path Enforcement
 
-Since Longhorn v1.5.0, Longhorn only allows upgrades from supported versions. If upgrading from any unsupported version, the upgrade will fail. However, users can revert to the previous state without any service interruption or downtime.
+Starting with v1.5.0, Longhorn only allows upgrades from supported versions. When you attempt to upgrade from an unsupported version, the upgrade automatically fails but you can revert to the previously installed version without any service interruption or downtime.
 
-In addition, Longhorn disallows downgrading to any previous version to prevent unexpected system statuses caused by potential function incompatibility, deprecation, or removal. Please refer to the following matrix to understand the supported upgrade versions and there is an example for each upgrade path:
+The following table outlines the supported upgrade paths.
 
-  |  Current version |  Upgrading version |  Allow | Example |
+  |  Current version |  Target version |  Allowed | Example |
   |    :-:      |    :-:      |   :-:  |    :-:    |
   |  x.y.*      |  x.(y+1).*  |   ✓    |  v1.4.2  to  v1.5.1  |
   |  x.y.*      |  x.y.(*+n)  |   ✓    |  v1.5.0  to  v1.5.1  |
@@ -25,10 +25,10 @@ In addition, Longhorn disallows downgrading to any previous version to prevent u
   |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.1  |
   |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
-[^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. (For example, v1.30.* is allowed to upgrade to v2.0.*, given that v1.30 is the last minor release branch before 2.0.)
+[^lastMinorVersion]: Longhorn only allows upgrades from a patch version of the last minor release before the new major version. For example, you can upgrade from v1.3.* to v2.0.* because v1.3.0 is the last minor release before v2.0.
 
-> **Warning**:
-> * Upgrade path enforcement is introduced in Longhorn v1.5.0, which means that downgrading from v1.5.0 to any previous version is possible. **Please note that downgrading is not supported**.
+> **Important**:
+> When you successfully upgrade to v1.6.0, you will not be allowed to revert to the previously installed version. This restriction helps prevent unexpected system behavior and issues caused by function incompatibility, deprecation, or removal.
 
 # Upgrading Longhorn
 


### PR DESCRIPTION
I reorganized and reworded the existing content, and added details from [this Slack thread](https://suse.slack.com/archives/C02HBK5AVC5/p1703730572042269).

My initial commit only covers v1.5.0 and v1.6.0, but I can expand the scope (if necessary) after I receive feedback.