### PR TITLE
Add aliases metadata to files in v2-data-engine

### DIFF
--- a/content/docs/1.5.3/v2-data-engine/_index.md
+++ b/content/docs/1.5.3/v2-data-engine/_index.md
@@ -1,4 +1,6 @@
 ---
 title: V2 Data Engine (Preview Feature)
 weight: 0
+aliases:
+- /spdk/_index.md
 ---

--- a/content/docs/1.5.3/v2-data-engine/automatic-offline-replica-rebuilding.md
+++ b/content/docs/1.5.3/v2-data-engine/automatic-offline-replica-rebuilding.md
@@ -1,6 +1,8 @@
 ---
 title: Automatic Offline Replica Rebuilding
 weight: 10
+aliases:
+- /spdk/automatic-offline-replica-rebuilding.md
 ---
 
 Longhorn currently does not support online replica rebuilding for volumes that use the V2 Data Engine. To overcome this limitation, an automatic offline replica rebuilding mechanism has been implemented. When a degraded volume is detached, Longhorn attaches the volume in maintenance mode and then initiates the rebuilding process. The volume is detached again once rebuilding is completed.

--- a/content/docs/1.5.3/v2-data-engine/features.md
+++ b/content/docs/1.5.3/v2-data-engine/features.md
@@ -1,6 +1,8 @@
 ---
 title: Features
 weight: 1
+aliases:
+- /spdk/features.md
 ---
 
 - Volume lifecycle (creation, attachment, detachment and deletion)

--- a/content/docs/1.5.3/v2-data-engine/performance-benchmark.md
+++ b/content/docs/1.5.3/v2-data-engine/performance-benchmark.md
@@ -1,6 +1,8 @@
 ---
-  title: Performance Benchmark
-  weight: 5
+title: Performance Benchmark
+weight: 5
+aliases:
+- /spdk/performance-benchmark.md
 ---
 
 ## Performance Measurement Tools

--- a/content/docs/1.5.3/v2-data-engine/prerequisites.md
+++ b/content/docs/1.5.3/v2-data-engine/prerequisites.md
@@ -1,6 +1,8 @@
 ---
 title: Prerequisites
 weight: 2
+aliases:
+- /spdk/prerequisites.md
 ---
 
 ## Prerequisites

--- a/content/docs/1.5.3/v2-data-engine/quick-start.md
+++ b/content/docs/1.5.3/v2-data-engine/quick-start.md
@@ -1,6 +1,8 @@
 ---
-  title: Quick Start
-  weight: 3
+title: Quick Start
+weight: 3
+aliases:
+- /spdk/quick-start.md
 ---
 
 **Table of Contents**

--- a/content/docs/1.5.3/v2-data-engine/troubleshooting.md
+++ b/content/docs/1.5.3/v2-data-engine/troubleshooting.md
@@ -1,6 +1,8 @@
 ---
 title: Troubleshooting
 weight: 6
+aliases:
+- /spdk/troubleshooting.md
 ---
 
 - [Installation](#installation)

--- a/content/docs/1.6.0/v2-data-engine/_index.md
+++ b/content/docs/1.6.0/v2-data-engine/_index.md
@@ -1,4 +1,6 @@
 ---
 title: V2 Data Engine (Preview Feature)
 weight: 0
+aliases:
+- /spdk/_index.md
 ---

--- a/content/docs/1.6.0/v2-data-engine/features/_index.md
+++ b/content/docs/1.6.0/v2-data-engine/features/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Features
 weight: 5
+aliases:
+- /spdk/features/_index.md
 ---
 
 - Support for AMD64 and ARM64 platforms

--- a/content/docs/1.6.0/v2-data-engine/features/automatic-offline-replica-rebuilding.md
+++ b/content/docs/1.6.0/v2-data-engine/features/automatic-offline-replica-rebuilding.md
@@ -2,7 +2,7 @@
 title: Automatic Offline Replica Rebuilding
 weight: 10
 aliases:
-- /spdk/features/automatic-offline-replica-rebuilding.md
+- /spdk/automatic-offline-replica-rebuilding.md
 ---
 
 Longhorn currently does not support online replica rebuilding for volumes that use the V2 Data Engine. To overcome this limitation, an automatic offline replica rebuilding mechanism has been implemented. When a degraded volume is detached, Longhorn attaches the volume in maintenance mode and then initiates the rebuilding process. The volume is detached again once rebuilding is completed.

--- a/content/docs/1.6.0/v2-data-engine/features/automatic-offline-replica-rebuilding.md
+++ b/content/docs/1.6.0/v2-data-engine/features/automatic-offline-replica-rebuilding.md
@@ -1,6 +1,8 @@
 ---
 title: Automatic Offline Replica Rebuilding
 weight: 10
+aliases:
+- /spdk/features/automatic-offline-replica-rebuilding.md
 ---
 
 Longhorn currently does not support online replica rebuilding for volumes that use the V2 Data Engine. To overcome this limitation, an automatic offline replica rebuilding mechanism has been implemented. When a degraded volume is detached, Longhorn attaches the volume in maintenance mode and then initiates the rebuilding process. The volume is detached again once rebuilding is completed.

--- a/content/docs/1.6.0/v2-data-engine/features/selective-v2-data-engine-activation.md
+++ b/content/docs/1.6.0/v2-data-engine/features/selective-v2-data-engine-activation.md
@@ -1,6 +1,8 @@
 ---
 title: Selective V2 Data Engine Activation
 weight: 20
+aliases:
+- /spdk/features/selective-v2-data-engine-activation.md
 ---
 
 Starting with v1.6.0, Longhorn allows you to enable or disable the V2 Data Engine on specific cluster nodes. You can choose to enable the V2 Data Engine only on powerful nodes in a cluster with varied power states. This is not possible in v1.5.0, which enables the V2 Data Engine on all nodes.

--- a/content/docs/1.6.0/v2-data-engine/performance.md
+++ b/content/docs/1.6.0/v2-data-engine/performance.md
@@ -1,6 +1,8 @@
 ---
 title: Performance
 weight: 3
+aliases:
+- /spdk/performance.md
 ---
 
 ## Performance Measurement Tools

--- a/content/docs/1.6.0/v2-data-engine/prerequisites.md
+++ b/content/docs/1.6.0/v2-data-engine/prerequisites.md
@@ -1,6 +1,8 @@
 ---
 title: Prerequisites
 weight: 1
+aliases:
+- /spdk/prerequisites.md
 ---
 
 ## Prerequisites

--- a/content/docs/1.6.0/v2-data-engine/quick-start.md
+++ b/content/docs/1.6.0/v2-data-engine/quick-start.md
@@ -1,6 +1,8 @@
 ---
-  title: Quick Start
-  weight: 2
+title: Quick Start
+weight: 2
+aliases:
+- /spdk/quick-start.md
 ---
 
 **Table of Contents**

--- a/content/docs/1.6.0/v2-data-engine/troubleshooting.md
+++ b/content/docs/1.6.0/v2-data-engine/troubleshooting.md
@@ -1,6 +1,8 @@
 ---
 title: Troubleshooting
 weight: 4
+aliases:
+- /spdk/troubleshooting.md
 ---
 
 - [Installation](#installation)


### PR DESCRIPTION
Google search results for topics related to the V2 Data Engine point to `longhorn.io > docs > latest > spdk`. However, the links are broken because the folder was changed to 'v2-data-engine'.

We can use [aliases](https://gohugo.io/content-management/urls/#aliases) to redirect to the new URLs. I added the metadata to the affected v1.5.3 and v1.6.0 files.