### PR TITLE
Correct setting name for disabling pre-upgrade checker

### DIFF
--- a/content/docs/1.6.0/deploy/install/install-with-argocd.md
+++ b/content/docs/1.6.0/deploy/install/install-with-argocd.md
@@ -47,9 +47,9 @@ weight: 12
           repoURL: https://charts.longhorn.io/
           targetRevision: v1.6.0 # Replace with the Longhorn version you'd like to install or upgrade to
           helm:
-            values: |
-              helmPreUpgradeCheckerJob:
-                enabled: false
+            valuesObject:
+              preUpgradeChecker:
+                jobEnabled: false
       destination:
         server: https://kubernetes.default.svc
         namespace: longhorn-system


### PR DESCRIPTION
#### What this PR does / why we need it:
The value seems to be outdated. The pre-upgrade checker job is actually `preUpgradeChecker.jobEnabled: false` when using the Helm chart for `v1.6.0`.
