### PR TITLE
Fix typo in `trim-filesystem.md`

### DIFF
--- a/content/docs/1.4.0/volumes-and-nodes/trim-filesystem.md
+++ b/content/docs/1.4.0/volumes-and-nodes/trim-filesystem.md
@@ -39,13 +39,13 @@ By design each valid snapshot of a Longhorn volume is immutable. Hence Longhorn 
 
 To help reclaim as much space as possible automatically, Longhorn introduces [setting _Remove Snapshots During Filesystem Trim_](../../references/settings/#remove-snapshots-during-filesystem-trim). This allows Longhorn filesystem trim feature to automatically mark the latest snapshot and its ancestors as removed and stops at the snapshot containing multiple children. As a result, Longhorn can reclaim space for as more snapshots as possible.
 
-#### The Volume Spec Field "UnmapMarkSnapChainAsRemoved"
+#### The Volume Spec Field "UnmapMarkSnapChainRemoved"
 
-Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainAsRemoved` would overwrite the global setting mentioned above.
+Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainRemoved` would overwrite the global setting mentioned above.
 
 There are 3 options for this volume field: `ignored`, `enabled`, and `disabled`. `ignored` means following the global setting, which is the default value.
 
-You can directly set this field in the StoragaClasses so that the customized value can be applied to all volumes created by the StorageClasses.
+You can directly set this field in the StorageClasses so that the customized value can be applied to all volumes created by the StorageClasses.
 
 ## Known Issues & Limitations
 

--- a/content/docs/1.4.1/volumes-and-nodes/trim-filesystem.md
+++ b/content/docs/1.4.1/volumes-and-nodes/trim-filesystem.md
@@ -38,13 +38,13 @@ By design each valid snapshot of a Longhorn volume is immutable. Hence Longhorn 
 
 To help reclaim as much space as possible automatically, Longhorn introduces [setting _Remove Snapshots During Filesystem Trim_](../../references/settings/#remove-snapshots-during-filesystem-trim). This allows Longhorn filesystem trim feature to automatically mark the latest snapshot and its ancestors as removed and stops at the snapshot containing multiple children. As a result, Longhorn can reclaim space for as more snapshots as possible.
 
-#### The Volume Spec Field "UnmapMarkSnapChainAsRemoved"
+#### The Volume Spec Field "UnmapMarkSnapChainRemoved"
 
-Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainAsRemoved` would overwrite the global setting mentioned above.
+Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainRemoved` would overwrite the global setting mentioned above.
 
 There are 3 options for this volume field: `ignored`, `enabled`, and `disabled`. `ignored` means following the global setting, which is the default value.
 
-You can directly set this field in the StoragaClasses so that the customized value can be applied to all volumes created by the StorageClasses.
+You can directly set this field in the StorageClasses so that the customized value can be applied to all volumes created by the StorageClasses.
 
 ## Known Issues & Limitations
 

--- a/content/docs/1.4.2/volumes-and-nodes/trim-filesystem.md
+++ b/content/docs/1.4.2/volumes-and-nodes/trim-filesystem.md
@@ -38,13 +38,13 @@ By design each valid snapshot of a Longhorn volume is immutable. Hence Longhorn 
 
 To help reclaim as much space as possible automatically, Longhorn introduces [setting _Remove Snapshots During Filesystem Trim_](../../references/settings/#remove-snapshots-during-filesystem-trim). This allows Longhorn filesystem trim feature to automatically mark the latest snapshot and its ancestors as removed and stops at the snapshot containing multiple children. As a result, Longhorn can reclaim space for as more snapshots as possible.
 
-#### The Volume Spec Field "UnmapMarkSnapChainAsRemoved"
+#### The Volume Spec Field "UnmapMarkSnapChainRemoved"
 
-Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainAsRemoved` would overwrite the global setting mentioned above.
+Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainRemoved` would overwrite the global setting mentioned above.
 
 There are 3 options for this volume field: `ignored`, `enabled`, and `disabled`. `ignored` means following the global setting, which is the default value.
 
-You can directly set this field in the StoragaClasses so that the customized value can be applied to all volumes created by the StorageClasses.
+You can directly set this field in the StorageClasses so that the customized value can be applied to all volumes created by the StorageClasses.
 
 ## Known Issues & Limitations
 

--- a/content/docs/1.4.3/volumes-and-nodes/trim-filesystem.md
+++ b/content/docs/1.4.3/volumes-and-nodes/trim-filesystem.md
@@ -38,13 +38,13 @@ By design each valid snapshot of a Longhorn volume is immutable. Hence Longhorn 
 
 To help reclaim as much space as possible automatically, Longhorn introduces [setting _Remove Snapshots During Filesystem Trim_](../../references/settings/#remove-snapshots-during-filesystem-trim). This allows Longhorn filesystem trim feature to automatically mark the latest snapshot and its ancestors as removed and stops at the snapshot containing multiple children. As a result, Longhorn can reclaim space for as more snapshots as possible.
 
-#### The Volume Spec Field "UnmapMarkSnapChainAsRemoved"
+#### The Volume Spec Field "UnmapMarkSnapChainRemoved"
 
-Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainAsRemoved` would overwrite the global setting mentioned above.
+Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainRemoved` would overwrite the global setting mentioned above.
 
 There are 3 options for this volume field: `ignored`, `enabled`, and `disabled`. `ignored` means following the global setting, which is the default value.
 
-You can directly set this field in the StoragaClasses so that the customized value can be applied to all volumes created by the StorageClasses.
+You can directly set this field in the StorageClasses so that the customized value can be applied to all volumes created by the StorageClasses.
 
 ## Known Issues & Limitations
 

--- a/content/docs/1.4.4/volumes-and-nodes/trim-filesystem.md
+++ b/content/docs/1.4.4/volumes-and-nodes/trim-filesystem.md
@@ -38,13 +38,13 @@ By design each valid snapshot of a Longhorn volume is immutable. Hence Longhorn 
 
 To help reclaim as much space as possible automatically, Longhorn introduces [setting _Remove Snapshots During Filesystem Trim_](../../references/settings/#remove-snapshots-during-filesystem-trim). This allows Longhorn filesystem trim feature to automatically mark the latest snapshot and its ancestors as removed and stops at the snapshot containing multiple children. As a result, Longhorn can reclaim space for as more snapshots as possible.
 
-#### The Volume Spec Field "UnmapMarkSnapChainAsRemoved"
+#### The Volume Spec Field "UnmapMarkSnapChainRemoved"
 
-Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainAsRemoved` would overwrite the global setting mentioned above.
+Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainRemoved` would overwrite the global setting mentioned above.
 
 There are 3 options for this volume field: `ignored`, `enabled`, and `disabled`. `ignored` means following the global setting, which is the default value.
 
-You can directly set this field in the StoragaClasses so that the customized value can be applied to all volumes created by the StorageClasses.
+You can directly set this field in the StorageClasses so that the customized value can be applied to all volumes created by the StorageClasses.
 
 ## Known Issues & Limitations
 

--- a/content/docs/1.4.5/volumes-and-nodes/trim-filesystem.md
+++ b/content/docs/1.4.5/volumes-and-nodes/trim-filesystem.md
@@ -38,13 +38,13 @@ By design each valid snapshot of a Longhorn volume is immutable. Hence Longhorn 
 
 To help reclaim as much space as possible automatically, Longhorn introduces [setting _Remove Snapshots During Filesystem Trim_](../../references/settings/#remove-snapshots-during-filesystem-trim). This allows Longhorn filesystem trim feature to automatically mark the latest snapshot and its ancestors as removed and stops at the snapshot containing multiple children. As a result, Longhorn can reclaim space for as more snapshots as possible.
 
-#### The Volume Spec Field "UnmapMarkSnapChainAsRemoved"
+#### The Volume Spec Field "UnmapMarkSnapChainRemoved"
 
-Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainAsRemoved` would overwrite the global setting mentioned above.
+Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainRemoved` would overwrite the global setting mentioned above.
 
 There are 3 options for this volume field: `ignored`, `enabled`, and `disabled`. `ignored` means following the global setting, which is the default value.
 
-You can directly set this field in the StoragaClasses so that the customized value can be applied to all volumes created by the StorageClasses.
+You can directly set this field in the StorageClasses so that the customized value can be applied to all volumes created by the StorageClasses.
 
 ## Known Issues & Limitations
 

--- a/content/docs/1.5.0/volumes-and-nodes/trim-filesystem.md
+++ b/content/docs/1.5.0/volumes-and-nodes/trim-filesystem.md
@@ -38,13 +38,13 @@ By design each valid snapshot of a Longhorn volume is immutable. Hence Longhorn 
 
 To help reclaim as much space as possible automatically, Longhorn introduces [setting _Remove Snapshots During Filesystem Trim_](../../references/settings/#remove-snapshots-during-filesystem-trim). This allows Longhorn filesystem trim feature to automatically mark the latest snapshot and its ancestors as removed and stops at the snapshot containing multiple children. As a result, Longhorn can reclaim space for as more snapshots as possible.
 
-#### The Volume Spec Field "UnmapMarkSnapChainAsRemoved"
+#### The Volume Spec Field "UnmapMarkSnapChainRemoved"
 
-Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainAsRemoved` would overwrite the global setting mentioned above.
+Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainRemoved` would overwrite the global setting mentioned above.
 
 There are 3 options for this volume field: `ignored`, `enabled`, and `disabled`. `ignored` means following the global setting, which is the default value.
 
-You can directly set this field in the StoragaClasses so that the customized value can be applied to all volumes created by the StorageClasses.
+You can directly set this field in the StorageClasses so that the customized value can be applied to all volumes created by the StorageClasses.
 
 ## Known Issues & Limitations
 

--- a/content/docs/1.5.1/volumes-and-nodes/trim-filesystem.md
+++ b/content/docs/1.5.1/volumes-and-nodes/trim-filesystem.md
@@ -56,13 +56,13 @@ By design each valid snapshot of a Longhorn volume is immutable. Hence Longhorn 
 
 To help reclaim as much space as possible automatically, Longhorn introduces [setting _Remove Snapshots During Filesystem Trim_](../../references/settings/#remove-snapshots-during-filesystem-trim). This allows Longhorn filesystem trim feature to automatically mark the latest snapshot and its ancestors as removed and stops at the snapshot containing multiple children. As a result, Longhorn can reclaim space for as more snapshots as possible.
 
-#### The Volume Spec Field "UnmapMarkSnapChainAsRemoved"
+#### The Volume Spec Field "UnmapMarkSnapChainRemoved"
 
-Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainAsRemoved` would overwrite the global setting mentioned above.
+Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainRemoved` would overwrite the global setting mentioned above.
 
 There are 3 options for this volume field: `ignored`, `enabled`, and `disabled`. `ignored` means following the global setting, which is the default value.
 
-You can directly set this field in the StoragaClasses so that the customized value can be applied to all volumes created by the StorageClasses.
+You can directly set this field in the StorageClasses so that the customized value can be applied to all volumes created by the StorageClasses.
 
 ## Known Issues & Limitations
 

--- a/content/docs/1.5.2/volumes-and-nodes/trim-filesystem.md
+++ b/content/docs/1.5.2/volumes-and-nodes/trim-filesystem.md
@@ -56,13 +56,13 @@ By design each valid snapshot of a Longhorn volume is immutable. Hence Longhorn 
 
 To help reclaim as much space as possible automatically, Longhorn introduces [setting _Remove Snapshots During Filesystem Trim_](../../references/settings/#remove-snapshots-during-filesystem-trim). This allows Longhorn filesystem trim feature to automatically mark the latest snapshot and its ancestors as removed and stops at the snapshot containing multiple children. As a result, Longhorn can reclaim space for as more snapshots as possible.
 
-#### The Volume Spec Field "UnmapMarkSnapChainAsRemoved"
+#### The Volume Spec Field "UnmapMarkSnapChainRemoved"
 
-Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainAsRemoved` would overwrite the global setting mentioned above.
+Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainRemoved` would overwrite the global setting mentioned above.
 
 There are 3 options for this volume field: `ignored`, `enabled`, and `disabled`. `ignored` means following the global setting, which is the default value.
 
-You can directly set this field in the StoragaClasses so that the customized value can be applied to all volumes created by the StorageClasses.
+You can directly set this field in the StorageClasses so that the customized value can be applied to all volumes created by the StorageClasses.
 
 ## Known Issues & Limitations
 

--- a/content/docs/1.5.3/volumes-and-nodes/trim-filesystem.md
+++ b/content/docs/1.5.3/volumes-and-nodes/trim-filesystem.md
@@ -60,13 +60,13 @@ By design each valid snapshot of a Longhorn volume is immutable. Hence Longhorn 
 
 To help reclaim as much space as possible automatically, Longhorn introduces [setting _Remove Snapshots During Filesystem Trim_](../../references/settings/#remove-snapshots-during-filesystem-trim). This allows Longhorn filesystem trim feature to automatically mark the latest snapshot and its ancestors as removed and stops at the snapshot containing multiple children. As a result, Longhorn can reclaim space for as more snapshots as possible.
 
-#### The Volume Spec Field "UnmapMarkSnapChainAsRemoved"
+#### The Volume Spec Field "UnmapMarkSnapChainRemoved"
 
-Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainAsRemoved` would overwrite the global setting mentioned above.
+Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainRemoved` would overwrite the global setting mentioned above.
 
 There are 3 options for this volume field: `ignored`, `enabled`, and `disabled`. `ignored` means following the global setting, which is the default value.
 
-You can directly set this field in the StoragaClasses so that the customized value can be applied to all volumes created by the StorageClasses.
+You can directly set this field in the StorageClasses so that the customized value can be applied to all volumes created by the StorageClasses.
 
 ## Known Issues & Limitations
 

--- a/content/docs/1.5.4/volumes-and-nodes/trim-filesystem.md
+++ b/content/docs/1.5.4/volumes-and-nodes/trim-filesystem.md
@@ -60,13 +60,13 @@ By design each valid snapshot of a Longhorn volume is immutable. Hence Longhorn 
 
 To help reclaim as much space as possible automatically, Longhorn introduces [setting _Remove Snapshots During Filesystem Trim_](../../references/settings/#remove-snapshots-during-filesystem-trim). This allows Longhorn filesystem trim feature to automatically mark the latest snapshot and its ancestors as removed and stops at the snapshot containing multiple children. As a result, Longhorn can reclaim space for as more snapshots as possible.
 
-#### The Volume Spec Field "UnmapMarkSnapChainAsRemoved"
+#### The Volume Spec Field "UnmapMarkSnapChainRemoved"
 
-Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainAsRemoved` would overwrite the global setting mentioned above.
+Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainRemoved` would overwrite the global setting mentioned above.
 
 There are 3 options for this volume field: `ignored`, `enabled`, and `disabled`. `ignored` means following the global setting, which is the default value.
 
-You can directly set this field in the StoragaClasses so that the customized value can be applied to all volumes created by the StorageClasses.
+You can directly set this field in the StorageClasses so that the customized value can be applied to all volumes created by the StorageClasses.
 
 ## Known Issues & Limitations
 

--- a/content/docs/1.6.0/nodes-and-volumes/volumes/trim-filesystem.md
+++ b/content/docs/1.6.0/nodes-and-volumes/volumes/trim-filesystem.md
@@ -60,13 +60,13 @@ By design each valid snapshot of a Longhorn volume is immutable. Hence Longhorn 
 
 To help reclaim as much space as possible automatically, Longhorn introduces [setting _Remove Snapshots During Filesystem Trim_](../../../references/settings/#remove-snapshots-during-filesystem-trim). This allows Longhorn filesystem trim feature to automatically mark the latest snapshot and its ancestors as removed and stops at the snapshot containing multiple children. As a result, Longhorn can reclaim space for as more snapshots as possible.
 
-#### The Volume Spec Field "UnmapMarkSnapChainAsRemoved"
+#### The Volume Spec Field "UnmapMarkSnapChainRemoved"
 
-Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainAsRemoved` would overwrite the global setting mentioned above.
+Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainRemoved` would overwrite the global setting mentioned above.
 
 There are 3 options for this volume field: `ignored`, `enabled`, and `disabled`. `ignored` means following the global setting, which is the default value.
 
-You can directly set this field in the StoragaClasses so that the customized value can be applied to all volumes created by the StorageClasses.
+You can directly set this field in the StorageClasses so that the customized value can be applied to all volumes created by the StorageClasses.
 
 ## Known Issues & Limitations
 

--- a/content/docs/1.6.1/nodes-and-volumes/volumes/trim-filesystem.md
+++ b/content/docs/1.6.1/nodes-and-volumes/volumes/trim-filesystem.md
@@ -60,13 +60,13 @@ By design each valid snapshot of a Longhorn volume is immutable. Hence Longhorn 
 
 To help reclaim as much space as possible automatically, Longhorn introduces [setting _Remove Snapshots During Filesystem Trim_](../../../references/settings/#remove-snapshots-during-filesystem-trim). This allows Longhorn filesystem trim feature to automatically mark the latest snapshot and its ancestors as removed and stops at the snapshot containing multiple children. As a result, Longhorn can reclaim space for as more snapshots as possible.
 
-#### The Volume Spec Field "UnmapMarkSnapChainAsRemoved"
+#### The Volume Spec Field "UnmapMarkSnapChainRemoved"
 
-Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainAsRemoved` would overwrite the global setting mentioned above.
+Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainRemoved` would overwrite the global setting mentioned above.
 
 There are 3 options for this volume field: `ignored`, `enabled`, and `disabled`. `ignored` means following the global setting, which is the default value.
 
-You can directly set this field in the StoragaClasses so that the customized value can be applied to all volumes created by the StorageClasses.
+You can directly set this field in the StorageClasses so that the customized value can be applied to all volumes created by the StorageClasses.
 
 ## Known Issues & Limitations
 

--- a/content/docs/1.7.0/nodes-and-volumes/volumes/trim-filesystem.md
+++ b/content/docs/1.7.0/nodes-and-volumes/volumes/trim-filesystem.md
@@ -60,13 +60,13 @@ By design each valid snapshot of a Longhorn volume is immutable. Hence Longhorn 
 
 To help reclaim as much space as possible automatically, Longhorn introduces [setting _Remove Snapshots During Filesystem Trim_](../../../references/settings/#remove-snapshots-during-filesystem-trim). This allows Longhorn filesystem trim feature to automatically mark the latest snapshot and its ancestors as removed and stops at the snapshot containing multiple children. As a result, Longhorn can reclaim space for as more snapshots as possible.
 
-#### The Volume Spec Field "UnmapMarkSnapChainAsRemoved"
+#### The Volume Spec Field "UnmapMarkSnapChainRemoved"
 
-Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainAsRemoved` would overwrite the global setting mentioned above.
+Of course there is a per-volume field `volume.Spec.UnmapMarkSnapChainRemoved` would overwrite the global setting mentioned above.
 
 There are 3 options for this volume field: `ignored`, `enabled`, and `disabled`. `ignored` means following the global setting, which is the default value.
 
-You can directly set this field in the StoragaClasses so that the customized value can be applied to all volumes created by the StorageClasses.
+You can directly set this field in the StorageClasses so that the customized value can be applied to all volumes created by the StorageClasses.
 
 ## Known Issues & Limitations
 


### PR DESCRIPTION
- Replaced `UnmapMarkSnapChainAsRemoved` -> `UnmapMarkSnapChainRemoved`
- Replaced `StoragaClasses` -> `StorageClasses`
