### PR TITLE
Add Freeze File System For Snapshot documentation

### DIFF
--- a/content/docs/1.7.0/best-practices.md
+++ b/content/docs/1.7.0/best-practices.md
@@ -63,15 +63,15 @@ The following Linux OS distributions and versions have been verified during the 
 | 6.  | Rocky Linux  | 9.3
 | 7.  | Talos Linux  | 1.6.1
 
-Longhorn relies on heavily on kernel functionality and it performs better on some kernel versions. In particular:
+Longhorn relies heavily on kernel functionality and performs better on some kernel versions. The following activities,
+in particular, benefit from usage of specific kernel versions.
 
-- Use a kernel with version >= `v5.8` for file system optimizations/improvements. See [this
-  issue](https://github.com/longhorn/longhorn/issues/2507#issuecomment-857195496) for details.
-- Use a kernel with version >= `5.17` if you plan to enable the [Freeze File System For
-  Snapshot](../references/settings#freeze-file-system-for-snapshot) setting to ensure a volume crash during a file
-  system freeze can't lock up a node.
-- Use a kernel with version >= `5.19` if you plan to enable the [v2 data engine](../v2-data-engine/prerequisites) to
-  ensure volume-related I/O errors can't unexpectedly reboot a node.
+- Optimizing or improving the filesystem: Use a kernel with version `v5.8` or later. See [Issue
+  #2507](https://github.com/longhorn/longhorn/issues/2507#issuecomment-857195496) for details.
+- Enabling the [Freeze Filesystem for Snapshot](../references/settings#freeze-filesystem-for-snapshot) setting: Use a
+  kernel with version `5.17` or later to ensure that a volume crash during a filesystem freeze cannot lock up a node.
+- Enabling the [V2 Data Engine](../v2-data-engine/prerequisites): Use a kernel with version `5.19` or later to ensure
+  that volume-related I/O errors cannot reboot a node unexpectedly.
 
 ## Kubernetes Version
 

--- a/content/docs/1.7.0/best-practices.md
+++ b/content/docs/1.7.0/best-practices.md
@@ -63,7 +63,15 @@ The following Linux OS distributions and versions have been verified during the 
 | 6.  | Rocky Linux  | 9.3
 | 7.  | Talos Linux  | 1.6.1
 
-Note: It's recommended to guarantee that the kernel version is at least 5.8 as there is filesystem optimization/improvement since this version. See [this issue](https://github.com/longhorn/longhorn/issues/2507#issuecomment-857195496) for details.
+Longhorn relies on heavily on kernel functionality and it performs better on some kernel versions. In particular:
+
+- Use a kernel with version >= `v5.8` for file system optimizations/improvements. See [this
+  issue](https://github.com/longhorn/longhorn/issues/2507#issuecomment-857195496) for details.
+- Use a kernel with version >= `5.17` if you plan to enable the [Freeze File System For
+  Snapshot](../references/settings#freeze-file-system-for-snapshot) setting to ensure a volume crash during a file
+  system freeze can't lock up a node.
+- Use a kernel with version >= `5.19` if you plan to enable the [v2 data engine](../v2-data-engine/prerequisites) to
+  ensure volume-related I/O errors can't unexpectedly reboot a node.
 
 ## Kubernetes Version
 

--- a/content/docs/1.7.0/references/helm-values.md
+++ b/content/docs/1.7.0/references/helm-values.md
@@ -32,7 +32,7 @@ The `values.yaml` file contains items used to tweak a deployment of this chart.
 | image.csi.attacher.repository | string | `"longhornio/csi-attacher"` | Repository for the CSI attacher image. When unspecified, Longhorn uses the default value. |
 | image.csi.attacher.tag | string | `"v4.4.2"` | Tag for the CSI attacher image. When unspecified, Longhorn uses the default value. |
 | image.csi.livenessProbe.repository | string | `"longhornio/livenessprobe"` | Repository for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
-| image.csi.livenessProbe.tag | string | `"v2.11.0"` | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
+| image.csi.livenessProbe.tag | string | `"v2.12.0"` | Tag for the CSI liveness probe image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.repository | string | `"longhornio/csi-node-driver-registrar"` | Repository for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
 | image.csi.nodeDriverRegistrar.tag | string | `"v2.9.2"` | Tag for the CSI Node Driver Registrar image. When unspecified, Longhorn uses the default value. |
 | image.csi.provisioner.repository | string | `"longhornio/csi-provisioner"` | Repository for the CSI Provisioner image. When unspecified, Longhorn uses the default value. |
@@ -52,7 +52,7 @@ The `values.yaml` file contains items used to tweak a deployment of this chart.
 | image.longhorn.shareManager.repository | string | `"longhornio/longhorn-share-manager"` | Repository for the Longhorn Share Manager image. |
 | image.longhorn.shareManager.tag | string | `"master-head"` | Tag for the Longhorn Share Manager image. |
 | image.longhorn.supportBundleKit.repository | string | `"longhornio/support-bundle-kit"` | Repository for the Longhorn Support Bundle Manager image. |
-| image.longhorn.supportBundleKit.tag | string | `"v0.0.33"` | Tag for the Longhorn Support Bundle Manager image. |
+| image.longhorn.supportBundleKit.tag | string | `"v0.0.37"` | Tag for the Longhorn Support Bundle Manager image. |
 | image.longhorn.ui.repository | string | `"longhornio/longhorn-ui"` | Repository for the Longhorn UI image. |
 | image.longhorn.ui.tag | string | `"master-head"` | Tag for the Longhorn UI image. |
 | image.openshift.oauthProxy.repository | string | `"longhornio/openshift-origin-oauth-proxy"` | Repository for the OAuth Proxy image. This setting applies only to OpenShift users. |
@@ -224,6 +224,7 @@ During installation, you can either allow Longhorn to use the default system set
 | defaultSettings.engineReplicaTimeout | Timeout between the Longhorn Engine and replicas. Specify a value between "8" and "30" seconds. The default value is "8". |
 | defaultSettings.failedBackupTTL | Number of minutes that Longhorn keeps a failed backup resource. When the value is "0", automatic deletion is disabled. |
 | defaultSettings.fastReplicaRebuildEnabled | Setting that allows fast rebuilding of replicas using the checksum of snapshot disk files. Before enabling this setting, you must set the snapshot-data-integrity value to "enable" or "fast-check". |
+| defaultSettings.freezeFSForSnapshot | Freeze the file system on the root partition before taking a snapshot. |
 | defaultSettings.guaranteedInstanceManagerCPU | Percentage of the total allocatable CPU resources on each node to be reserved for each instance manager pod when the V1 Data Engine is enabled. The default value is "12". |
 | defaultSettings.kubernetesClusterAutoscalerEnabled | Setting that notifies Longhorn that the cluster is using the Kubernetes Cluster Autoscaler. |
 | defaultSettings.logLevel | Log levels that indicate the type and severity of logs in Longhorn Manager. The default value is "Info". (Options: "Panic", "Fatal", "Error", "Warn", "Info", "Debug", "Trace") |
@@ -247,6 +248,7 @@ During installation, you can either allow Longhorn to use the default system set
 | defaultSettings.snapshotDataIntegrity | Setting that allows you to enable and disable snapshot hashing and data integrity checks. |
 | defaultSettings.snapshotDataIntegrityCronjob | Setting that defines when Longhorn checks the integrity of data in snapshot disk files. You must use the Unix cron expression format. |
 | defaultSettings.snapshotDataIntegrityImmediateCheckAfterSnapshotCreation | Setting that allows disabling of snapshot hashing after snapshot creation to minimize impact on system performance. |
+| defaultSettings.snapshotMaxCount | Maximum snapshot count for a volume. The value should be between 2 to 250 |
 | defaultSettings.storageMinimalAvailablePercentage | Percentage of minimum available disk capacity. When the minimum available capacity exceeds the total available capacity, the disk becomes unschedulable until more space is made available for use. The default value is "25". |
 | defaultSettings.storageNetwork | Storage network for in-cluster traffic. When unspecified, Longhorn uses the Kubernetes cluster network. |
 | defaultSettings.storageOverProvisioningPercentage | Percentage of storage that can be allocated relative to hard drive capacity. The default value is "100". |

--- a/content/docs/1.7.0/references/helm-values.md
+++ b/content/docs/1.7.0/references/helm-values.md
@@ -224,7 +224,7 @@ During installation, you can either allow Longhorn to use the default system set
 | defaultSettings.engineReplicaTimeout | Timeout between the Longhorn Engine and replicas. Specify a value between "8" and "30" seconds. The default value is "8". |
 | defaultSettings.failedBackupTTL | Number of minutes that Longhorn keeps a failed backup resource. When the value is "0", automatic deletion is disabled. |
 | defaultSettings.fastReplicaRebuildEnabled | Setting that allows fast rebuilding of replicas using the checksum of snapshot disk files. Before enabling this setting, you must set the snapshot-data-integrity value to "enable" or "fast-check". |
-| defaultSettings.freezeFSForSnapshot | Freeze the file system on the root partition before taking a snapshot. |
+| defaultSettings.freezeFilesystemForSnapshot | Setting that freezes the filesystem on the root partition before a snapshot is created. |
 | defaultSettings.guaranteedInstanceManagerCPU | Percentage of the total allocatable CPU resources on each node to be reserved for each instance manager pod when the V1 Data Engine is enabled. The default value is "12". |
 | defaultSettings.kubernetesClusterAutoscalerEnabled | Setting that notifies Longhorn that the cluster is using the Kubernetes Cluster Autoscaler. |
 | defaultSettings.logLevel | Log levels that indicate the type and severity of logs in Longhorn Manager. The default value is "Info". (Options: "Panic", "Fatal", "Error", "Warn", "Info", "Debug", "Trace") |

--- a/content/docs/1.7.0/references/settings.md
+++ b/content/docs/1.7.0/references/settings.md
@@ -47,7 +47,7 @@ weight: 1
   - [Immediate Snapshot Data Integrity Check After Creating a Snapshot](#immediate-snapshot-data-integrity-check-after-creating-a-snapshot)
   - [Snapshot Data Integrity Check CronJob](#snapshot-data-integrity-check-cronjob)
   - [Snapshot Maximum Count](#snapshot-maximum-count)
-  - [Freeze File System For Snapshot](#freeze-file-system-for-snapshot)
+  - [Freeze Filesystem For Snapshot](#freeze-filesystem-for-snapshot)
 - [Orphan](#orphan)
   - [Orphaned Data Automatic Deletion](#orphaned-data-automatic-deletion)
 - [Backups](#backups)
@@ -515,36 +515,35 @@ Unix-cron string format. The setting specifies when Longhorn checks the data int
 
 Maximum snapshot count for a volume. The value should be between 2 to 250.
 
-#### Freeze File System For Snapshot
+#### Freeze Filesystem For Snapshot
 
 > Default: `false`
 
-This setting only affects volumes with Kubernetes volume mode `Filesystem`. When enabled, Longhorn will freeze the file
-system on a volume immediately before taking a user-initiated snapshot. When the Kubernetes volume mode is `Block`, or
-when this setting is disabled, Longhorn will attempt a system sync immediately before taking a user-initiated snapshot
-instead.
+This setting only applies to volumes with the Kubernetes volume mode `Filesystem`. When enabled, Longhorn freezes the
+volume's filesystem immediately before creating a user-initiated snapshot. When disabled or when the Kubernetes volume
+mode is `Block`, Longhorn instead attempts a system sync before creating a user-initiated snapshot.
 
-A snapshot taken with this setting enabled has a higher consistency guarantee, as the file system is definitely in a
-consistent state at the moment of the snapshot. However, under very heavy I/O, the freeze may take noticeable time and
-cause workload activity to pause.
+Snapshots created when this setting is enabled are more likely to be consistent because the filesystem is in a
+consistent state at the moment of creation. However, under very heavy I/O, freezing the filesystem may take a
+significant amount of time and may cause workload activity to pause.
 
-With this setting disabled, all data is flushed to disk just before the snapshot is taken, but Longhorn cannot guarantee
-additional writes do not reach disk in the brief interval between the system sync and the snapshot. I/O is not paused
-during the system sync, so workloads likely do not notice a snapshot being taken.
+When this setting is disabled, all data is flushed to disk just before the snapshot is created, but Longhorn cannot
+completely block write attempts during the brief interval between the system sync and snapshot creation. I/O is not
+paused during the system sync, so workloads likely do not notice that a snapshot is being created.
 
-This setting defaults to `false` because kernels with version <= `v5.17` may not respond correctly when a volume crashes
-while a freeze is ongoing. While this is not likely to happen, if it does, an affected kernel will not allow the file
-system to unmount or the processes using the file system to be killed without a node reboot. Only enable this setting if
-you plan to use kernels with version >= `5.17` and ext4 or XFS file systems.
+The default option for this setting is `false` because kernels with version `v5.17` or earlier may not respond correctly
+when a volume crashes while a freeze is ongoing. This is not likely to happen but if it does, an affected kernel will
+not allow you to unmount the filesystem or stop processes using the filesystem without rebooting the node. Only enable
+this setting if you plan to use kernels with version `5.17` or later, and ext4 or XFS filesystems.
 
-This setting can be overridden for specific volumes in the UI, a storage-class, or by directly modifying an existing
-volume. The overriding field, `freezeFSForSnapshot` can take the following values:
+You can override this setting (using the field `freezeFilesystemForSnapshot`) for specific volumes through the Longhorn
+UI, a StorageClass, or direct changes to an existing volume. `freezeFilesystemForSnapshot` accepts the following values:
 
 > Default: `ignored`
 
-- `ignored`: This is the default option that instructs Longhorn to inherit from the global setting.
-- `enabled`: This option instructs Longhorn to restore volume recurring jobs/groups from the backup target forcibly.
-- `disabled`: This option instructs Longhorn no restoring volume recurring jobs/groups should be done.
+- `ignored`: Instructs Longhorn to use the global setting. This is the default option.
+- `enabled`: Enables freezing before snapshots, regardless of the global setting.
+- `disabled`: Disables freezing before snapshots, regardless of the global setting.
 
 ### Orphan
 

--- a/content/docs/1.7.0/references/storage-class-parameters.md
+++ b/content/docs/1.7.0/references/storage-class-parameters.md
@@ -41,6 +41,7 @@ parameters:
 #  nfsOptions: "soft,timeo=150,retrans=3"
 #  v1DataEngine: true
 #  v2DataEngine: false
+#  freezeFSForSnapshot: "ignored"
 ```
 
 ## Built-in Fields
@@ -225,7 +226,14 @@ A list of recurring jobs that are to be run on a volume.
 > Global setting: [V2 Data Engine](../settings#v2-data-engine).  
 > More details in [V2 Data Engine Quick Start](../../v2-data-engine/quick-start#create-a-storageclass).
 
+#### Freeze File System For Snapshot *(field: `parameters.freezeFSForSnapshot`)*
+> Default: `ignored`
+
+  - "ignored" means use the global setting.
+  - Other values are "enabled" and "disabled".
+
+> Global setting: [Freeze File System For Snapshot](../settings#freeze-file-system-for-snapshot).
+
 ## Helm Installs
 
 If Longhorn is installed via Helm, values in the default storage class can be set by editing the corresponding item in [values.yaml](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/chart/values.yaml).  All of the Storage Class parameters have a prefix of "persistence".  For example, `persistence.defaultNodeSelector`.
-

--- a/content/docs/1.7.0/references/storage-class-parameters.md
+++ b/content/docs/1.7.0/references/storage-class-parameters.md
@@ -226,13 +226,13 @@ A list of recurring jobs that are to be run on a volume.
 > Global setting: [V2 Data Engine](../settings#v2-data-engine).  
 > More details in [V2 Data Engine Quick Start](../../v2-data-engine/quick-start#create-a-storageclass).
 
-#### Freeze File System For Snapshot *(field: `parameters.freezeFSForSnapshot`)*
+#### Freeze Filesystem For Snapshot *(field: `parameters.freezeFilesystemForSnapshot`)*
 > Default: `ignored`
 
-  - "ignored" means use the global setting.
+  - "ignored" instructs Longhorn to use the global setting.
   - Other values are "enabled" and "disabled".
 
-> Global setting: [Freeze File System For Snapshot](../settings#freeze-file-system-for-snapshot).
+> Global setting: [Freeze File System For Snapshot](../settings#freeze-filesystem-for-snapshot).
 
 ## Helm Installs
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#2187

#### What this PR does / why we need it:

- Document the new freeze related global and volume-specific settings.
- Since there are now three different reasons we recommend a particular kernel version, make it easy to find all three recommendations.