### PR TITLE
Update backing image clean up action according to latest UI change

### DIFF
--- a/content/docs/1.5.0/advanced-resources/backing-image.md
+++ b/content/docs/1.5.0/advanced-resources/backing-image.md
@@ -159,5 +159,5 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 ## History
 * Available since v1.1.1 [Enable backing image feature in Longhorn](https://github.com/Longhorn/Longhorn/issues/2006)
-* Support [upload]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
-* Support [download to local]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.
+* Support [upload](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
+* Support [download to local](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.

--- a/content/docs/1.5.1/advanced-resources/backing-image.md
+++ b/content/docs/1.5.1/advanced-resources/backing-image.md
@@ -159,5 +159,5 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 ## History
 * Available since v1.1.1 [Enable backing image feature in Longhorn](https://github.com/Longhorn/Longhorn/issues/2006)
-* Support [upload]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
-* Support [download to local]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.
+* Support [upload](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
+* Support [download to local](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.

--- a/content/docs/1.5.2/advanced-resources/backing-image.md
+++ b/content/docs/1.5.2/advanced-resources/backing-image.md
@@ -159,5 +159,5 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 ## History
 * Available since v1.1.1 [Enable backing image feature in Longhorn](https://github.com/Longhorn/Longhorn/issues/2006)
-* Support [upload]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
-* Support [download to local]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.
+* Support [upload](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
+* Support [download to local](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.

--- a/content/docs/1.5.3/advanced-resources/backing-image.md
+++ b/content/docs/1.5.3/advanced-resources/backing-image.md
@@ -159,5 +159,5 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 ## History
 * Available since v1.1.1 [Enable backing image feature in Longhorn](https://github.com/Longhorn/Longhorn/issues/2006)
-* Support [upload]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
-* Support [download to local]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.
+* Support [upload](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
+* Support [download to local](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.

--- a/content/docs/1.5.4/advanced-resources/backing-image.md
+++ b/content/docs/1.5.4/advanced-resources/backing-image.md
@@ -159,5 +159,5 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 ## History
 * Available since v1.1.1 [Enable backing image feature in Longhorn](https://github.com/Longhorn/Longhorn/issues/2006)
-* Support [upload]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
-* Support [download to local]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.
+* Support [upload](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
+* Support [download to local](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.

--- a/content/docs/1.5.5/advanced-resources/backing-image.md
+++ b/content/docs/1.5.5/advanced-resources/backing-image.md
@@ -159,5 +159,5 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 ## History
 * Available since v1.1.1 [Enable backing image feature in Longhorn](https://github.com/Longhorn/Longhorn/issues/2006)
-* Support [upload]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
-* Support [download to local]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.
+* Support [upload](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
+* Support [download to local](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.

--- a/content/docs/1.5.6/advanced-resources/backing-image.md
+++ b/content/docs/1.5.6/advanced-resources/backing-image.md
@@ -159,5 +159,5 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 ## History
 * Available since v1.1.1 [Enable backing image feature in Longhorn](https://github.com/Longhorn/Longhorn/issues/2006)
-* Support [upload]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
-* Support [download to local]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.
+* Support [upload](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
+* Support [download to local](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.

--- a/content/docs/1.6.0/advanced-resources/backing-image/backing-image.md
+++ b/content/docs/1.6.0/advanced-resources/backing-image/backing-image.md
@@ -160,5 +160,5 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 ## History
 * Available since v1.1.1 [Enable backing image feature in Longhorn](https://github.com/Longhorn/Longhorn/issues/2006)
-* Support [upload]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
-* Support [download to local]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.
+* Support [upload](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
+* Support [download to local](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.

--- a/content/docs/1.6.1/advanced-resources/backing-image/backing-image.md
+++ b/content/docs/1.6.1/advanced-resources/backing-image/backing-image.md
@@ -160,5 +160,5 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 ## History
 * Available since v1.1.1 [Enable backing image feature in Longhorn](https://github.com/Longhorn/Longhorn/issues/2006)
-* Support [upload]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
-* Support [download to local]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.
+* Support [upload](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
+* Support [download to local](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.

--- a/content/docs/1.6.2/advanced-resources/backing-image/backing-image.md
+++ b/content/docs/1.6.2/advanced-resources/backing-image/backing-image.md
@@ -160,5 +160,5 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 ## History
 * Available since v1.1.1 [Enable backing image feature in Longhorn](https://github.com/Longhorn/Longhorn/issues/2006)
-* Support [upload]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
-* Support [download to local]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.
+* Support [upload](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
+* Support [download to local](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.

--- a/content/docs/1.6.3/advanced-resources/backing-image/backing-image.md
+++ b/content/docs/1.6.3/advanced-resources/backing-image/backing-image.md
@@ -160,5 +160,5 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 ## History
 * Available since v1.1.1 [Enable backing image feature in Longhorn](https://github.com/Longhorn/Longhorn/issues/2006)
-* Support [upload]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
-* Support [download to local]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.
+* Support [upload](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
+* Support [download to local](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.

--- a/content/docs/1.6.3/advanced-resources/backing-image/backing-image.md
+++ b/content/docs/1.6.3/advanced-resources/backing-image/backing-image.md
@@ -133,7 +133,7 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 #### Clean up backing images in disks
 - Longhorn automatically cleans up the unused backing image files in the disks based on [the setting `Backing Image Cleanup Wait Interval`](../../../references/settings#backing-image-cleanup-wait-interval). But Longhorn will retain at least one file in a disk for each backing image anyway.
-- The unused backing images can be also cleaned up manually via the Longhorn UI: Click **Setting > Backing Image > Operation list of one backing image > Clean Up**. Then choose disks.
+- The unused backing images can be also cleaned up manually via the Longhorn UI: Click **Setting > Backing Image > one backing image name**. Then choose disks to clean up.
 - Once there is one replica in a disk using a backing image, no matter what the replica's current state is, the backing image file in this disk cannot be cleaned up.
 
 #### Delete backing images

--- a/content/docs/1.6.3/advanced-resources/backing-image/backing-image.md
+++ b/content/docs/1.6.3/advanced-resources/backing-image/backing-image.md
@@ -133,7 +133,7 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 #### Clean up backing images in disks
 - Longhorn automatically cleans up the unused backing image files in the disks based on [the setting `Backing Image Cleanup Wait Interval`](../../../references/settings#backing-image-cleanup-wait-interval). But Longhorn will retain at least one file in a disk for each backing image anyway.
-- The unused backing images can be also cleaned up manually via the Longhorn UI: Click **Setting > Backing Image > one backing image name**. Then choose disks to clean up.
+- You can manually remove backing images from disks using the Longhorn UI. Go to **Setting** > **Backing Image**, and then click the name of a specific backing image. In the window that opens, select one or more disks and then click **Clean Up**.
 - Once there is one replica in a disk using a backing image, no matter what the replica's current state is, the backing image file in this disk cannot be cleaned up.
 
 #### Delete backing images

--- a/content/docs/1.7.0/advanced-resources/backing-image/backing-image.md
+++ b/content/docs/1.7.0/advanced-resources/backing-image/backing-image.md
@@ -194,5 +194,5 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 ## History
 * Available since v1.1.1 [Enable backing image feature in Longhorn](https://github.com/Longhorn/Longhorn/issues/2006)
-* Support [upload]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
-* Support [download to local]((https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.
+* Support [upload](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/2403) since v1.2.0.
+* Support [download to local](https://github.com/longhorn/longhorn/issues/2404) and [volume exporting](https://github.com/longhorn/longhorn/issues/3155) since v1.3.0.

--- a/content/docs/1.7.0/advanced-resources/backing-image/backing-image.md
+++ b/content/docs/1.7.0/advanced-resources/backing-image/backing-image.md
@@ -30,7 +30,7 @@ You can prepare a backing image using four different kinds of data sources.
 - The replicas cannot be scheduled on nodes or disks where the backing image cannot be scheduled.
 
 #### Number of copies
-- You can add `minNumberOfCopies` to ensure that multiple backing image files exist in the cluster. 
+- You can add `minNumberOfCopies` to ensure that multiple backing image files exist in the cluster.
 - You can adjust the `minNumberOfCopies` in the global setting to apply the default value to the BackingImage.
 
 ### The way of creating a backing image
@@ -158,7 +158,7 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 #### Clean up backing images in disks
 - Longhorn automatically cleans up the unused backing image files in the disks based on [the setting `Backing Image Cleanup Wait Interval`](../../../references/settings#backing-image-cleanup-wait-interval). But Longhorn will retain at least one file in a disk for each backing image anyway.
-- The unused backing images can be also cleaned up manually via the Longhorn UI: Click **Setting > Backing Image > Operation list of one backing image > Clean Up**. Then choose disks.
+- The unused backing images can be also cleaned up manually via the Longhorn UI: Click **Setting > Backing Image > one backing image name**. Then choose disks to clean up.
 - Once there is one replica in a disk using a backing image, no matter what the replica's current state is, the backing image file in this disk cannot be cleaned up.
 
 #### Delete backing images

--- a/content/docs/1.7.0/advanced-resources/backing-image/backing-image.md
+++ b/content/docs/1.7.0/advanced-resources/backing-image/backing-image.md
@@ -158,7 +158,7 @@ Since v1.3.0, users can download existing backing image files to the local via U
 
 #### Clean up backing images in disks
 - Longhorn automatically cleans up the unused backing image files in the disks based on [the setting `Backing Image Cleanup Wait Interval`](../../../references/settings#backing-image-cleanup-wait-interval). But Longhorn will retain at least one file in a disk for each backing image anyway.
-- The unused backing images can be also cleaned up manually via the Longhorn UI: Click **Setting > Backing Image > one backing image name**. Then choose disks to clean up.
+- You can manually remove backing images from disks using the Longhorn UI. Go to **Setting** > **Backing Image**, and then click the name of a specific backing image. In the window that opens, select one or more disks and then click **Clean Up**.
 - Once there is one replica in a disk using a backing image, no matter what the replica's current state is, the backing image file in this disk cannot be cleaned up.
 
 #### Delete backing images


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
[[IMPROVEMENT] BackingImage UI improvement](https://github.com/longhorn/longhorn/issues/7293)

Issue #
[[IMPROVEMENT] BackingImage UI improvement](https://github.com/longhorn/longhorn/issues/7293)

#### What this PR does / why we need it:
- Update backing image clean up action due to the [PR moves clean up into backing image detail modal](https://github.com/longhorn/longhorn-ui/pull/729) (for v1.7.0 and v1.6.3) 
- Fix extra left parentheses in the end of backing-image.md for all versions.

**Before fix**
<img width="975" alt="Screenshot 2024-05-27 at 12 00 16 PM" src="https://github.com/longhorn/website/assets/5744158/078bf658-44eb-4b5f-bf10-642df6de6303">

**After fix**
<img width="808" alt="image" src="https://github.com/longhorn/website/assets/5744158/39584c98-a2df-46c5-8d36-1d5f1ef3e6ab">



