### PR TITLE
Mention kernel-default-base doesn't include iscsi_tcp

### DIFF
--- a/content/docs/1.5.0/deploy/install/_index.md
+++ b/content/docs/1.5.0/deploy/install/_index.md
@@ -159,6 +159,8 @@ Please ensure iscsi_tcp module has been loaded before iscsid service starts. Gen
 modprobe iscsi_tcp
 ```
 
+> **Important**: On SUSE and openSUSE, the `iscsi_tcp` module is included only in the `kernel-default` package. If the `kernel-default-base` package is installed on your system, you must replace it with `kernel-default`.
+
 We also provide an `iscsi` installer to make it easier for users to install `open-iscsi` automatically:
 ```
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/prerequisite/longhorn-iscsi-installation.yaml

--- a/content/docs/1.5.1/deploy/install/_index.md
+++ b/content/docs/1.5.1/deploy/install/_index.md
@@ -159,6 +159,8 @@ Please ensure iscsi_tcp module has been loaded before iscsid service starts. Gen
 modprobe iscsi_tcp
 ```
 
+> **Important**: On SUSE and openSUSE, the `iscsi_tcp` module is included only in the `kernel-default` package. If the `kernel-default-base` package is installed on your system, you must replace it with `kernel-default`.
+
 We also provide an `iscsi` installer to make it easier for users to install `open-iscsi` automatically:
 ```
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/prerequisite/longhorn-iscsi-installation.yaml

--- a/content/docs/1.5.2/deploy/install/_index.md
+++ b/content/docs/1.5.2/deploy/install/_index.md
@@ -161,6 +161,8 @@ Please ensure iscsi_tcp module has been loaded before iscsid service starts. Gen
 modprobe iscsi_tcp
 ```
 
+> **Important**: On SUSE and openSUSE, the `iscsi_tcp` module is included only in the `kernel-default` package. If the `kernel-default-base` package is installed on your system, you must replace it with `kernel-default`.
+
 We also provide an `iscsi` installer to make it easier for users to install `open-iscsi` automatically:
 ```
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/prerequisite/longhorn-iscsi-installation.yaml

--- a/content/docs/1.5.3/deploy/install/_index.md
+++ b/content/docs/1.5.3/deploy/install/_index.md
@@ -161,6 +161,8 @@ Please ensure iscsi_tcp module has been loaded before iscsid service starts. Gen
 modprobe iscsi_tcp
 ```
 
+> **Important**: On SUSE and openSUSE, the `iscsi_tcp` module is included only in the `kernel-default` package. If the `kernel-default-base` package is installed on your system, you must replace it with `kernel-default`.
+
 We also provide an `iscsi` installer to make it easier for users to install `open-iscsi` automatically:
 ```
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/prerequisite/longhorn-iscsi-installation.yaml

--- a/content/docs/1.5.4/deploy/install/_index.md
+++ b/content/docs/1.5.4/deploy/install/_index.md
@@ -161,6 +161,8 @@ Please ensure iscsi_tcp module has been loaded before iscsid service starts. Gen
 modprobe iscsi_tcp
 ```
 
+> **Important**: On SUSE and openSUSE, the `iscsi_tcp` module is included only in the `kernel-default` package. If the `kernel-default-base` package is installed on your system, you must replace it with `kernel-default`.
+
 We also provide an `iscsi` installer to make it easier for users to install `open-iscsi` automatically:
 ```
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/prerequisite/longhorn-iscsi-installation.yaml

--- a/content/docs/1.5.5/deploy/install/_index.md
+++ b/content/docs/1.5.5/deploy/install/_index.md
@@ -161,6 +161,8 @@ Please ensure iscsi_tcp module has been loaded before iscsid service starts. Gen
 modprobe iscsi_tcp
 ```
 
+> **Important**: On SUSE and openSUSE, the `iscsi_tcp` module is included only in the `kernel-default` package. If the `kernel-default-base` package is installed on your system, you must replace it with `kernel-default`.
+
 We also provide an `iscsi` installer to make it easier for users to install `open-iscsi` automatically:
 ```
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/prerequisite/longhorn-iscsi-installation.yaml

--- a/content/docs/1.5.6/deploy/install/_index.md
+++ b/content/docs/1.5.6/deploy/install/_index.md
@@ -161,6 +161,8 @@ Please ensure iscsi_tcp module has been loaded before iscsid service starts. Gen
 modprobe iscsi_tcp
 ```
 
+> **Important**: On SUSE and openSUSE, the `iscsi_tcp` module is included only in the `kernel-default` package. If the `kernel-default-base` package is installed on your system, you must replace it with `kernel-default`.
+
 We also provide an `iscsi` installer to make it easier for users to install `open-iscsi` automatically:
 ```
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/prerequisite/longhorn-iscsi-installation.yaml

--- a/content/docs/1.6.0/deploy/install/_index.md
+++ b/content/docs/1.6.0/deploy/install/_index.md
@@ -167,6 +167,8 @@ Please ensure iscsi_tcp module has been loaded before iscsid service starts. Gen
 modprobe iscsi_tcp
 ```
 
+> **Important**: On SUSE and openSUSE, the `iscsi_tcp` module is included only in the `kernel-default` package. If the `kernel-default-base` package is installed on your system, you must replace it with `kernel-default`.
+
 We also provide an `iscsi` installer to make it easier for users to install `open-iscsi` automatically:
 ```
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/prerequisite/longhorn-iscsi-installation.yaml

--- a/content/docs/1.6.1/deploy/install/_index.md
+++ b/content/docs/1.6.1/deploy/install/_index.md
@@ -167,6 +167,8 @@ Please ensure iscsi_tcp module has been loaded before iscsid service starts. Gen
 modprobe iscsi_tcp
 ```
 
+> **Important**: On SUSE and openSUSE, the `iscsi_tcp` module is included only in the `kernel-default` package. If the `kernel-default-base` package is installed on your system, you must replace it with `kernel-default`.
+
 We also provide an `iscsi` installer to make it easier for users to install `open-iscsi` automatically:
 ```
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/prerequisite/longhorn-iscsi-installation.yaml

--- a/content/docs/1.6.2/deploy/install/_index.md
+++ b/content/docs/1.6.2/deploy/install/_index.md
@@ -167,9 +167,7 @@ Please ensure iscsi_tcp module has been loaded before iscsid service starts. Gen
 modprobe iscsi_tcp
 ```
 
-Note that on SUSE and openSUSE, the iscsi_tcp module is included in the `kernel-default` package, but
-is not available in `kernel-default-base`. If you have `kernel-default-base` installed, you will need
-to install `kernel-default` instead.
+> **Important**: On SUSE and openSUSE, the `iscsi_tcp` module is included only in the `kernel-default` package. If the `kernel-default-base` package is installed on your system, you must replace it with `kernel-default`.
 
 We also provide an `iscsi` installer to make it easier for users to install `open-iscsi` automatically:
 ```

--- a/content/docs/1.6.2/deploy/install/_index.md
+++ b/content/docs/1.6.2/deploy/install/_index.md
@@ -167,6 +167,10 @@ Please ensure iscsi_tcp module has been loaded before iscsid service starts. Gen
 modprobe iscsi_tcp
 ```
 
+Note that on SUSE and openSUSE, the iscsi_tcp module is included in the `kernel-default` package, but
+is not available in `kernel-default-base`. If you have `kernel-default-base` installed, you will need
+to install `kernel-default` instead.
+
 We also provide an `iscsi` installer to make it easier for users to install `open-iscsi` automatically:
 ```
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/prerequisite/longhorn-iscsi-installation.yaml

--- a/content/docs/1.6.3/deploy/install/_index.md
+++ b/content/docs/1.6.3/deploy/install/_index.md
@@ -167,6 +167,8 @@ Please ensure iscsi_tcp module has been loaded before iscsid service starts. Gen
 modprobe iscsi_tcp
 ```
 
+> **Important**: On SUSE and openSUSE, the `iscsi_tcp` module is included only in the `kernel-default` package. If the `kernel-default-base` package is installed on your system, you must replace it with `kernel-default`.
+
 We also provide an `iscsi` installer to make it easier for users to install `open-iscsi` automatically:
 ```
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/prerequisite/longhorn-iscsi-installation.yaml

--- a/content/docs/1.7.0/deploy/install/_index.md
+++ b/content/docs/1.7.0/deploy/install/_index.md
@@ -170,6 +170,8 @@ Please ensure iscsi_tcp module has been loaded before iscsid service starts. Gen
 modprobe iscsi_tcp
 ```
 
+> **Important**: On SUSE and openSUSE, the `iscsi_tcp` module is included only in the `kernel-default` package. If the `kernel-default-base` package is installed on your system, you must replace it with `kernel-default`.
+
 We also provide an `iscsi` installer to make it easier for users to install `open-iscsi` automatically:
 ```
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/prerequisite/longhorn-iscsi-installation.yaml


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/8697

#### What this PR does / why we need it:

To inform SUSE users that they need `kernel-default` installed to get the `iscsi_tcp` module, vs. `kernel-default-base` which is a minimal kernel package for use on VMs.

#### Special notes for your reviewer:

I've only updated the 1.6.2 docs initially, just in case my text needs rewording or moving or whatever. Once everyone's happy with the text, I'll add this update to other versions as well.

#### Additional documentation or context
