### PR TITLE
docs(1.7.0): update danger zone settings block

### DIFF
--- a/content/docs/1.7.0/deploy/important-notes/index.md
+++ b/content/docs/1.7.0/deploy/important-notes/index.md
@@ -146,7 +146,7 @@ Starting with Longhorn v1.6.0, Longhorn allows you to modify the [Danger Zone se
 - No attached volumes: When no volumes are attached before the settings are configured, the setting changes are immediately applied.
 - Engine image upgrade (live upgrade): During a live upgrade, which involves creating a new Instance Manager pod, the setting changes are immediately applied to the new pod.
 
-Settings are synchronized hourly. When all volumes are detached, the settings in the following table are immediately applied and the system-managed components (for example, Instance Manager, CSI Driver, and engine images) are restarted. If you do not detach all volumes before the settings are synchronized, the settings are not applied and you must reconfigure the same settings after detaching the remaining volumes.
+Settings are synchronized hourly. When all volumes are detached, the settings in the following table are immediately applied and the system-managed components (for example, Instance Manager, CSI Driver, and engine images) are restarted. If you do not detach all volumes before the settings are synchronized, the settings are not applied and you must reconfigure the same settings after detaching the remaining volumes. The unapplied settings will be shown at the top of the danger zone settings in the Longhorn UI.
 
   | Setting | Additional Information| Affected Components |
   | --- | --- | --- |

--- a/content/docs/1.7.0/deploy/important-notes/index.md
+++ b/content/docs/1.7.0/deploy/important-notes/index.md
@@ -146,7 +146,9 @@ Starting with Longhorn v1.6.0, Longhorn allows you to modify the [Danger Zone se
 - No attached volumes: When no volumes are attached before the settings are configured, the setting changes are immediately applied.
 - Engine image upgrade (live upgrade): During a live upgrade, which involves creating a new Instance Manager pod, the setting changes are immediately applied to the new pod.
 
-Settings are synchronized hourly. When all volumes are detached, the settings in the following table are immediately applied and the system-managed components (for example, Instance Manager, CSI Driver, and engine images) are restarted. If you do not detach all volumes before the settings are synchronized, the settings are not applied and you must reconfigure the same settings after detaching the remaining volumes. The unapplied settings will be shown at the top of the danger zone settings in the Longhorn UI.
+Settings are synchronized hourly. When all volumes are detached, the settings in the following table are immediately applied and the system-managed components (for example, Instance Manager, CSI Driver, and engine images) are restarted.
+
+If you do not detach all volumes before the settings are synchronized, the settings are not applied and you must reconfigure the same settings after detaching the remaining volumes. You can view the list of unapplied settings in the **Danger Zone** section of the Longhorn UI.
 
   | Setting | Additional Information| Affected Components |
   | --- | --- | --- |

--- a/content/docs/1.7.0/references/settings.md
+++ b/content/docs/1.7.0/references/settings.md
@@ -794,7 +794,9 @@ Starting with Longhorn v1.6.0, Longhorn allows you to modify the [Danger Zone se
 - No attached volumes: When no volumes are attached before the settings are configured, the setting changes are immediately applied.
 - Engine image upgrade (live upgrade): During a live upgrade, which involves creating a new Instance Manager pod, the setting changes are immediately applied to the new pod.
 
-Settings are synchronized hourly. When all volumes are detached, the settings in the following table are immediately applied and the system-managed components (for example, Instance Manager, CSI Driver, and Engine images) are restarted. If you do not detach all volumes before the settings are synchronized, the settings are not applied and you must reconfigure the same settings after detaching the remaining volumes.
+Settings are synchronized hourly. When all volumes are detached, the settings in the following table are immediately applied and the system-managed components (for example, Instance Manager, CSI Driver, and engine images) are restarted.
+
+If you do not detach all volumes before the settings are synchronized, the settings are not applied and you must reconfigure the same settings after detaching the remaining volumes. You can view the list of unapplied settings in the **Danger Zone** section of the Longhorn UI.
 
   | Setting | Additional Information| Affected Components |
   | --- | --- | --- |


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue # [[UI][IMPROVEMENT] Improve the UX of updating danger zone settings](https://github.com/longhorn/longhorn/issues/8071)

#### What this PR does / why we need it:
Due to UI PR change, the unapplied danger zone settings will show up on the top of danger zone block.
See recording in https://github.com/longhorn/longhorn-ui/pull/735

#### Special notes for your reviewer:
N/A
#### Additional documentation or context
N/A