### PR TITLE
docs(1.7.0): update v2-data-engine/prerequisites.md

### DIFF
--- a/content/docs/1.7.0/v2-data-engine/prerequisites.md
+++ b/content/docs/1.7.0/v2-data-engine/prerequisites.md
@@ -21,6 +21,11 @@ Longhorn nodes must meet the following requirements:
   >
   > Host machines with Linux kernel 5.15 may unexpectedly reboot when volume-related IO errors occur. Update the Linux kernel on Longhorn nodes to version 5.19 or later to prevent such issues.
 
+  v6.7 or later is recommended for improved system stability
+  > **NOTICE**
+  >
+  > Memory corruption may occur on hosts using versions of the Linux kernel earlier than 6.7, as highlighted by this SPDK upstream issue: https://github.com/spdk/spdk/issues/3116#issuecomment-1890984674. In Longhorn environment the kernel panic can be caused by prevalent IO timeouts in communications between the nvme-tcp driver and SPDK. Update the Linux kernel on Longhorn nodes to version 6.7 or later to prevent the issue from occurring.
+
 - Linux kernel modules
   - uio
   - uio_pci_generic


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #7703 #7697 #7693 #7559

#### What this PR does / why we need it:

Kernel >= 6.7 is recommended to avoid memory corruption inside the system when IO timeouts happen massively between nvme-tcp driver and SPDK. This release contain a better error handling.

#### Special notes for your reviewer:

#### Additional documentation or context
