### PR TITLE
Update docs to reference longhorn namespace for installation daemonsets

### DIFF
--- a/content/docs/1.6.3/deploy/install/_index.md
+++ b/content/docs/1.6.3/deploy/install/_index.md
@@ -175,13 +175,13 @@ kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< curren
 ```
 After the deployment, run the following command to check pods' status of the installer:
 ```
-kubectl get pod | grep longhorn-iscsi-installation
+kubectl -n longhorn-system get pod | grep longhorn-iscsi-installation
 longhorn-iscsi-installation-49hd7   1/1     Running   0          21m
 longhorn-iscsi-installation-pzb7r   1/1     Running   0          39m
 ```
 And also can check the log with the following command to see the installation result:
 ```
-kubectl logs longhorn-iscsi-installation-pzb7r -c iscsi-installation
+kubectl -n longhorn-system logs longhorn-iscsi-installation-pzb7r -c iscsi-installation
 ...
 Installed:
   iscsi-initiator-utils.x86_64 0:6.2.0.874-7.amzn2
@@ -238,14 +238,14 @@ kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< curren
 ```
 After the deployment, run the following command to check pods' status of the installer:
 ```
-kubectl get pod | grep longhorn-nfs-installation
+kubectl -n longhorn-system get pod | grep longhorn-nfs-installation
 NAME                                  READY   STATUS    RESTARTS   AGE
 longhorn-nfs-installation-t2v9v   1/1     Running   0          143m
 longhorn-nfs-installation-7nphm   1/1     Running   0          143m
 ```
 And also can check the log with the following command to see the installation result:
 ```
-kubectl logs longhorn-nfs-installation-t2v9v -c nfs-installation
+kubectl -n longhorn-system logs longhorn-nfs-installation-t2v9v -c nfs-installation
 ...
 nfs install successfully
 ```

--- a/content/docs/1.7.0/advanced-resources/os-distro-specific/container-optimized-os-support.md
+++ b/content/docs/1.7.0/advanced-resources/os-distro-specific/container-optimized-os-support.md
@@ -41,7 +41,7 @@ Longhorn provides a GKE COS node agent daemonset, which leverages GKE Kubernetes
 1. Check the agent pod's status.
     Example:
     ```
-    $ kubectl get pod -l app=longhorn-gke-cos-node
+    $ kubectl -n longhorn-system get pod -l app=longhorn-gke-cos-node
     NAME                                READY   STATUS    RESTARTS      AGE
     longhorn-gke-cos-node-agent-222w8   1/1     Running   1 (86m ago)   86m
     longhorn-gke-cos-node-agent-8r26h   1/1     Running   1 (86m ago)   86m

--- a/content/docs/1.7.0/deploy/install/_index.md
+++ b/content/docs/1.7.0/deploy/install/_index.md
@@ -225,13 +225,13 @@ kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< curren
 ```
 After the deployment, run the following command to check pods' status of the installer:
 ```
-kubectl get pod | grep longhorn-iscsi-installation
+kubectl -n longhorn-system get pod | grep longhorn-iscsi-installation
 longhorn-iscsi-installation-49hd7   1/1     Running   0          21m
 longhorn-iscsi-installation-pzb7r   1/1     Running   0          39m
 ```
 And also can check the log with the following command to see the installation result:
 ```
-kubectl logs longhorn-iscsi-installation-pzb7r -c iscsi-installation
+kubectl -n longhorn-system logs longhorn-iscsi-installation-pzb7r -c iscsi-installation
 ...
 Installed:
   iscsi-initiator-utils.x86_64 0:6.2.0.874-7.amzn2
@@ -290,14 +290,14 @@ kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/v{{< curren
 ```
 After the deployment, run the following command to check pods' status of the installer:
 ```
-kubectl get pod | grep longhorn-nfs-installation
+kubectl -n longhorn-system get pod | grep longhorn-nfs-installation
 NAME                                  READY   STATUS    RESTARTS   AGE
 longhorn-nfs-installation-t2v9v   1/1     Running   0          143m
 longhorn-nfs-installation-7nphm   1/1     Running   0          143m
 ```
 And also can check the log with the following command to see the installation result:
 ```
-kubectl logs longhorn-nfs-installation-t2v9v -c nfs-installation
+kubectl -n longhorn-system logs longhorn-nfs-installation-t2v9v -c nfs-installation
 ...
 nfs install successfully
 ```


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/8855

#### What this PR does / why we need it:
Old exemplar commands won't work once namespace is changed

#### Special notes for your reviewer:

#### Additional documentation or context
https://github.com/longhorn/longhorn/pull/8856
