### PR TITLE
doc(backup): add full backup support doc

### DIFF
--- a/content/docs/1.7.0/snapshots-and-backups/backup-and-restore/create-a-backup.md
+++ b/content/docs/1.7.0/snapshots-and-backups/backup-and-restore/create-a-backup.md
@@ -3,10 +3,12 @@ title: Create a Backup
 weight: 2
 ---
 
+## Incremental Backup
 Backups in Longhorn are objects in an off-cluster backupstore. A backup of a snapshot is copied to the backupstore, and the endpoint to access the backupstore is the backup target. For more information, see [this section.](../../../concepts/#31-how-backups-work)
 
 > **Prerequisite:** A backup target must be set up. For more information, see [Set the BackupTarget](../set-backup-target). If the BackupTarget has not been set, you'll be presented with an error.
 
+### Create an Incremental Backup Using UI
 To create a backup,
 
 1. Navigate to the **Volume** menu.
@@ -16,4 +18,67 @@ To create a backup,
 
 **Result:** The backup is created. To see it, click **Backup** in the top navigation bar.
 
-For information on how to restore a volume from a snapshot, refer to [this page.](../restore-from-a-backup)
+For information about restoring a volume from a snapshot, see [Restore from a Backup](../restore-from-a-backup).
+
+### Create an Incremental Using YAML Code
+
+1. Obtain the name of the snapshot that you want to back up (from either the Longhorn UI or the CR).
+2. Apply the YAML.
+
+Example:
+
+```yaml
+apiVersion: longhorn.io/v1beta2
+kind: Backup
+metadata:
+  name: backup-example
+  namespace: longhorn-system
+spec:
+  backupMode: incremental
+  snapshotName: snapshot-name-example
+  labels:
+    app: test
+```
+
+## Full Backup
+
+By default, Longhorn backs up only data that was changed since the last backup. This approach, known as *delta backup*, enhances time efficiency and conserves network throughput. However, when a data block in the backupstore becomes corrupted, Longhorn does not replace that data block with a healthy one during subsequent backup operations.
+
+Starting with v1.7.0, Longhorn can perform full backups that upload all data blocks in the volume and overwrite existing data blocks in the backupstore.
+
+### Create a Full Backup Using the Longhorn UI
+1. Go to the **Volume** screen.
+2. Select the volume that you want to back up.
+3. Click **Create Backup**.
+4. Add appropriate labels.
+5. Select Full Backup.
+6. Click **OK**.
+
+### Create a Full Backup Using YAML Code
+1. Obtain the name of the snapshot that you want to back up (from either the Longhorn UI or the CR).
+2. Apply the YAML.
+
+Example:
+
+```yaml
+apiVersion: longhorn.io/v1beta2
+kind: Backup
+metadata:
+  name: backup-example
+  namespace: longhorn-system
+spec:
+  backupMode: full
+  snapshotName: snapshot-name-example
+  labels:
+    app: test
+```
+
+## Uploaded Data Size
+
+To facilitate collection of data transfer information for each backup, Longhorn records the information using two metrics in the CR status.
+
+### Newly Uploaded Data Size
+`status.newlyUploadDataSize` records the size of data that was uploaded *for the first time* to the backupstore during the latest backup. In other words, it tracks the size of data blocks that did not previously exist in the backupstore.
+
+### Re-Uploaded Data Size
+`status.reUploadDataSize` records the size of data that was overwritten during the latest full backup. In other words, it tracks the size of data blocks that previously existed in the backupstore.

--- a/content/docs/1.7.0/snapshots-and-backups/scheduling-backups-and-snapshots.md
+++ b/content/docs/1.7.0/snapshots-and-backups/scheduling-backups-and-snapshots.md
@@ -14,6 +14,8 @@ You can configure,
 - The number of backups or snapshots to retain
 - The number of jobs to run concurrently
 - Any labels that should be applied to the backup or snapshot
+- Parameters that should be applied to the backup
+  - `full-backup-interval`: Number of incremental backups that must be completed before Longhorn performs a full backup. This integer parameter is applied only to the backup. Notice that if the value is 0, Longhorn performs a incremental backup every time. For more information, see [Periodic Full Backup](#periodic-full-backup) and [Create a Backup](../backup-and-restore/create-a-backup).
 
 Recurring jobs can be set up using the Longhorn UI, `kubectl`, or by using a Longhorn `RecurringJob`.
 
@@ -220,3 +222,11 @@ You can find the setting in Longhorn UI.
 When the setting is enabled, Longhorn will automatically attach the volume and take a snapshot/backup when it is time to do a recurring snapshot/backup.
 
 Note that during the time the volume was attached automatically, the volume is not ready for the workload. Workload will have to wait until the recurring job finishes.
+
+## Periodic Full Backup
+
+Longhorn performs delta backups by default, which means that only data that was changed since the last backup is uploaded. However, when a data block in the backupstore becomes corrupted, Longhorn does not replace that data block with a healthy one during subsequent backup operations. Corrupted data blocks in the backupstore may cause restoration operations to fail.
+When a non-zero `full-backup-interval` parameter is set, Longhorn performs a full backup every `full-backup-interval` incremental backups. During a full backup, Longhorn uploads all data blocks in the volume. Data blocks that exist in the backupstore, including corrupted ones, are overwritten.
+
+> **Important**: 
+> Performing a full backup might take longer and generate higher network throughput and costs than the default incremental backup.


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/7070

Add documents for full backup support
This feature depends on the UI, so the documents focus on the UI operation.