### PR TITLE
update install doc to enable and start iscsi

### DIFF
--- a/content/docs/1.7.0/deploy/install/_index.md
+++ b/content/docs/1.7.0/deploy/install/_index.md
@@ -145,6 +145,8 @@ You may need to edit the cluster security group to allow SSH access.
 - SUSE and openSUSE: Run the following command:
   ```
   zypper install open-iscsi
+  systemctl enable iscsid
+  systemctl start iscsid
   ```
 
 - Debian and Ubuntu: Run the following command:


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates the doc as the SUSE/OpenSUSE section does not cover enabling and starting the iscsid service

#### Special notes for your reviewer:

#### Additional documentation or context
`longhorn-test-01:~ # systemctl enable iscsid
Created symlink /etc/systemd/system/multi-user.target.wants/iscsid.service → /usr/lib/systemd/system/iscsid.service.`