### PR TITLE
docs(v1.7.0): Add note about possible RWX fast-failover deadlock situ…

### DIFF
--- a/content/docs/1.7.0/deploy/important-notes/index.md
+++ b/content/docs/1.7.0/deploy/important-notes/index.md
@@ -155,6 +155,8 @@ For more information, see [Issue #8184](https://github.com/longhorn/longhorn/iss
 
 RWX Volumes fast failover is introduced in Longhorn v1.7.0 to improve resilience to share-manager pod failures. This failover mechanism quickly detects and responds to share-manager pod failures independently of the Kubernetes node failure sequence and timing. For details, see [RWX Volume Fast Failover](../../high-availability/rwx-volume-fast-failover).
 
+> **Note:**  In rare circumstances, it is possible for the failover to become deadlocked. This happens if the NFS server pod creation is blocked by a recovery action that is itself blocked by the failover-in-process state.  If the feature is enabled, and a failover takes more than a minute or two, it is probably stuck in this situation.  There is an explanation and a workaround in [RWX Volume Fast Failover](../../high-availability/rwx-volume-fast-failover).
+
 ### Support Configurable Timeout for Replica Rebuilding and Snapshot cloning
 
 Since Longhorn v1.7.0, configurable timeouts for replica rebuilding and snapshot cloning are supported. Prior to v1.7.0, the timeout for replica rebuilding was capped at 24 hours, which could cause failures for large volumes in slow bandwidth environments. Now, the timeout is still 24 hours by default but can be adjusted to accommodate different environments. More information can be found [Settings Reference](http://0.0.0.0:8085/docs/1.7.0/references/settings/#long-grpc-timeout).

--- a/content/docs/1.7.0/high-availability/rwx-volume-fast-failover.md
+++ b/content/docs/1.7.0/high-availability/rwx-volume-fast-failover.md
@@ -14,3 +14,9 @@ Along with adding the monitoring and fast reaction, the feature also changes the
 If the setting is changed back to "false", the lease check is disabled and pod relocation will use regular Kubernetes rules for node failure, even on existing volumes.  When the server pod is next restarted, it will revert to the normal grace period configuration.
 
 For more information, see https://github.com/longhorn/longhorn/issues/6205.
+
+> **Note:**  In rare circumstances, it is possible for the failover to become deadlocked. This happens if the NFS server pod creation is blocked by a recovery action that is itself blocked by the failover-in-process state.  If that is the case, and failover takes more than a minute or two, the workaround is to delete the associated lease object.  That clears the state, and a new lease is created along with the replacement server pod.  For example, if the stuck volume is named `pvc-2ce4e82e-7ccc-46c0-90a8-a141501fbf93` and the feature is enabled, there will be a lease with the same name.  To delete the associated lease object:
+> ```bash
+> kubectl -n longhorn-system delete lease pvc-2ce4e82e-7ccc-46c0-90a8-a141501fbf93
+> ```
+> See, for example, https://github.com/longhorn/longhorn/issues/9093.


### PR DESCRIPTION
…ation.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Warning mentioned in https://github.com/longhorn/longhorn/issues/9093#issuecomment-2256250764

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
