### PR TITLE
doc(spdk): enable uio_pci_generic and vfio_pci kernel modules

### DIFF
--- a/content/docs/1.7.0/deploy/important-notes/index.md
+++ b/content/docs/1.7.0/deploy/important-notes/index.md
@@ -22,7 +22,7 @@ Please see [here](https://github.com/longhorn/longhorn/releases/tag/v{{< current
   - [High Availability of Backing Images](#high-availability-of-backing-images)
 - [V2 Data Engine](#v2-data-engine)
   - [Longhorn System Upgrade](#longhorn-system-upgrade)
-  - [Using `vfio_pci` as the Default Userspace I/O Driver for Bare-Metal and Virtualized Environments](#using-vfio_pci-as-the-default-userspace-io-driver-for-bare-metal-and-virtualized-environments)
+  - [Enable Both `vfio_pci` and `uio_pci_generic` Kernel Modules](#enable-both-vfio_pci-and-uio_pci_generic-kernel-modules)
   - [Introduction of Online Replica Rebuilding](#introduction-of-online-replica-rebuilding)
   - [Block-type Disk Supports SPDK AIO, NVMe and VirtIO Bdev Drivers](#block-type-disk-supports-spdk-aio-nvme-and-virtio-bdev-drivers)
   - [Introduction of Filesystem Trim](#introduction-of-filesystem-trim)
@@ -175,9 +175,9 @@ To address the single point of failure (SPOF) issue with backing images, high av
 
 Longhorn currently does not support live upgrading of V2 volumes. Ensure that all V2 volumes are detached before initiating the upgrade process.
 
-### Using `vfio_pci` as the Default Userspace I/O Driver for Bare-Metal and Virtualized Environments
+### Enable Both `vfio_pci` and `uio_pci_generic` Kernel Modules
 
-For improved compatibility with both bare-metal and virtualized environments, it is recommended to use `vfio_pci` as the default Userspace I/O Driver. For more information, see this [link](https://github.com/longhorn/longhorn/issues/8813).
+According to the [SPDK System Configuration User Guide](https://spdk.io/doc/system_configuration.html), neither `vfio_pci` nor `uio_pci_generic` is universally suitable for all devices and environments. Therefore, users can enable both `vfio_pci` and `uio_pci_generic` kernel modules, allowing Longhorn to automatically select the appropriate module. For more information, see this [link](https://github.com/longhorn/longhorn/issues/9182).
 
 ### Introduction of Online Replica Rebuilding
 

--- a/content/docs/1.7.0/deploy/important-notes/index.md
+++ b/content/docs/1.7.0/deploy/important-notes/index.md
@@ -177,7 +177,7 @@ Longhorn currently does not support live upgrading of V2 volumes. Ensure that al
 
 ### Enable Both `vfio_pci` and `uio_pci_generic` Kernel Modules
 
-According to the [SPDK System Configuration User Guide](https://spdk.io/doc/system_configuration.html), neither `vfio_pci` nor `uio_pci_generic` is universally suitable for all devices and environments. Therefore, users can enable both `vfio_pci` and `uio_pci_generic` kernel modules, allowing Longhorn to automatically select the appropriate module. For more information, see this [link](https://github.com/longhorn/longhorn/issues/9182).
+According to the [SPDK System Configuration User Guide](https://spdk.io/doc/system_configuration.html), neither `vfio_pci` nor `uio_pci_generic` is universally suitable for all devices and environments. Therefore, users can enable both `vfio_pci` and `uio_pci_generic` kernel modules. This allows Longhorn to automatically select the appropriate module. For more information, see this [link](https://github.com/longhorn/longhorn/issues/9182).
 
 ### Introduction of Online Replica Rebuilding
 

--- a/content/docs/1.7.0/v2-data-engine/prerequisites.md
+++ b/content/docs/1.7.0/v2-data-engine/prerequisites.md
@@ -24,7 +24,7 @@ Longhorn nodes must meet the following requirements:
   v6.7 or later is recommended for improved system stability
   > **NOTICE**
   >
-  > Memory corruption may occur on hosts using versions of the Linux kernel earlier than 6.7, as highlighted by this SPDK upstream issue: https://github.com/spdk/spdk/issues/3116#issuecomment-1890984674. In Longhorn environment the kernel panic can be caused by prevalent IO timeouts in communications between the `nvme-tcp` driver and SPDK. Update the Linux kernel on Longhorn nodes to version 6.7 or later to prevent the issue from occurring.
+  > Memory corruption may occur on hosts using versions of the Linux kernel earlier than 6.7, as highlighted by this SPDK upstream issue: https://github.com/spdk/spdk/issues/3116#issuecomment-1890984674. In Longhorn environments the kernel panic can be caused by prevalent IO timeouts in communications between the `nvme-tcp` driver and SPDK. Update the Linux kernel on Longhorn nodes to version 6.7 or later to prevent the issue from occurring.
 
 - Linux kernel modules
   - `vfio_pci`

--- a/content/docs/1.7.0/v2-data-engine/prerequisites.md
+++ b/content/docs/1.7.0/v2-data-engine/prerequisites.md
@@ -24,11 +24,12 @@ Longhorn nodes must meet the following requirements:
   v6.7 or later is recommended for improved system stability
   > **NOTICE**
   >
-  > Memory corruption may occur on hosts using versions of the Linux kernel earlier than 6.7, as highlighted by this SPDK upstream issue: https://github.com/spdk/spdk/issues/3116#issuecomment-1890984674. In Longhorn environment the kernel panic can be caused by prevalent IO timeouts in communications between the nvme-tcp driver and SPDK. Update the Linux kernel on Longhorn nodes to version 6.7 or later to prevent the issue from occurring.
+  > Memory corruption may occur on hosts using versions of the Linux kernel earlier than 6.7, as highlighted by this SPDK upstream issue: https://github.com/spdk/spdk/issues/3116#issuecomment-1890984674. In Longhorn environment the kernel panic can be caused by prevalent IO timeouts in communications between the `nvme-tcp` driver and SPDK. Update the Linux kernel on Longhorn nodes to version 6.7 or later to prevent the issue from occurring.
 
 - Linux kernel modules
   - `vfio_pci`
-  - nvme-tcp
+  - `uio_pci_generic`
+  - `nvme-tcp`
 
 - Huge page support
   - 2 GiB of 2 MiB-sized pages

--- a/content/docs/1.7.0/v2-data-engine/quick-start.md
+++ b/content/docs/1.7.0/v2-data-engine/quick-start.md
@@ -65,6 +65,7 @@ Or, you can install them manually by following these steps.
 - Load the kernel modules on the each Longhorn node
   ```
   modprobe vfio_pci
+  modprobe uio_pci_generic
   ```
 
 - Configure huge pages
@@ -94,7 +95,7 @@ Or, you can manually load `nvme-tcp` kernel module on the each Longhorn node
 
 ### Load Kernel Modules Automatically on Boot
 
-Rather than manually loading kernel modules `vfio_pci` and `nvme-tcp` each time after reboot, you can streamline the process by configuring automatic module loading during the boot sequence. For detailed instructions, please consult the manual provided by your operating system.
+Rather than manually loading kernel modules `vfio_pci`, `uio_pci_generic` and `nvme-tcp` each time after reboot, you can streamline the process by configuring automatic module loading during the boot sequence. For detailed instructions, please consult the manual provided by your operating system.
 
 Reference:
 - [SUSE/OpenSUSE: Loading kernel modules automatically on boot](https://documentation.suse.com/sles/15-SP4/html/SLES-all/cha-mod.html#sec-mod-modprobe-d)


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#9182

#### What this PR does / why we need it:

According to the [SPDK System Configuration User Guide](https://spdk.io/doc/system_configuration.html), neither uio_pci_generic nor vfio_pci is universally suitable for all devices and environments. Therefore, the preflight installation enables both uio_pci_generic and vfio_pci kernel modules, allowing spdk/setup.sh to automatically select the appropriate module.


#### Special notes for your reviewer:

#### Additional documentation or context
