### PR TITLE
doc(uninstall): Add tip about working around missing webhook service.

### DIFF
--- a/content/docs/1.7.0/deploy/uninstall/_index.md
+++ b/content/docs/1.7.0/deploy/uninstall/_index.md
@@ -175,7 +175,7 @@ longhorn-webhook-mutator   1          46d
 rancher.cattle.io          4          133d
 ```
 
-If either or both are still registered, deleting the configuration will remove them from the patch operation call path.
+If either or both are still registered, you can delete the configuration to remove the services from the patch operation call path.
 
 ```shell
 $ kubectl delete ValidatingWebhookConfiguration longhorn-webhook-validator

--- a/content/docs/1.7.0/deploy/uninstall/_index.md
+++ b/content/docs/1.7.0/deploy/uninstall/_index.md
@@ -185,7 +185,7 @@ $ kubectl delete MutatingWebhookConfiguration longhorn-webhook-mutator
 mutatingwebhookconfiguration.admissionregistration.k8s.io "longhorn-webhook-mutator" deleted
 ```
 
-After that, the script should be successful:
+The script should run successfully after the configuration is deleted.
 
 ```shell
 Warning: Detected changes to resource pvc-279e8c3e-bfb0-4233-8899-77b5b178c08c which is currently being deleted.

--- a/content/docs/1.7.0/deploy/uninstall/_index.md
+++ b/content/docs/1.7.0/deploy/uninstall/_index.md
@@ -155,11 +155,11 @@ for crd in $(kubectl get crd -o jsonpath={.items[*].metadata.name} | tr ' ' '\n'
 done
 ```
 
-**Tip**:
-If that gets an error like this
-> for: "STDIN": error when patching "STDIN": Internal error occurred: failed calling webhook "validator.longhorn.io": failed to call webhook: Post "https://longhorn-admission-webhook.longhorn-system.svc:9502/v1/webhook/validation?timeout=10s": service "longhorn-admission-webhook" not found
+If you encounter the following error, it is possible that an incomplete uninstallation removed the Longhorn validation or modification webhook services, but left the same services registered.  
 
-It is possible that an incomplete uninstall might remove the Longhorn validation or modification webhook services, but leave them registered.  You can check that 
+`for: "STDIN": error when patching "STDIN": Internal error occurred: failed calling webhook "validator.longhorn.io": failed to call webhook: Post "https://longhorn-admission-webhook.longhorn-system.svc:9502/v1/webhook/validation?timeout=10s": service "longhorn-admission-webhook" not found`
+
+You can run the following commands to check the status of the webhook services.
 
 ```shell
 $ kubectl get ValidatingWebhookConfiguration -A

--- a/content/docs/1.7.0/deploy/uninstall/_index.md
+++ b/content/docs/1.7.0/deploy/uninstall/_index.md
@@ -155,5 +155,44 @@ for crd in $(kubectl get crd -o jsonpath={.items[*].metadata.name} | tr ' ' '\n'
 done
 ```
 
+**Tip**:
+If that gets an error like this
+> for: "STDIN": error when patching "STDIN": Internal error occurred: failed calling webhook "validator.longhorn.io": failed to call webhook: Post "https://longhorn-admission-webhook.longhorn-system.svc:9502/v1/webhook/validation?timeout=10s": service "longhorn-admission-webhook" not found
+
+It is possible that an incomplete uninstall might remove the Longhorn validation or modification webhook services, but leave them registered.  You can check that 
+
+```shell
+$ kubectl get ValidatingWebhookConfiguration -A
+NAME                               WEBHOOKS   AGE
+longhorn-webhook-validator         1          46d
+rancher.cattle.io                  7          133d
+rke2-ingress-nginx-admission       1          133d
+rke2-snapshot-validation-webhook   1          133d
+
+$ kubectl get MutatingWebhookConfiguration -A
+NAME                       WEBHOOKS   AGE
+longhorn-webhook-mutator   1          46d
+rancher.cattle.io          4          133d
+```
+
+If either or both are still registered, deleting the configuration will remove them from the patch operation call path.
+
+```shell
+$ kubectl delete ValidatingWebhookConfiguration longhorn-webhook-validator
+validatingwebhookconfiguration.admissionregistration.k8s.io "longhorn-webhook-validator" deleted
+
+$ kubectl delete MutatingWebhookConfiguration longhorn-webhook-mutator
+mutatingwebhookconfiguration.admissionregistration.k8s.io "longhorn-webhook-mutator" deleted
+```
+
+After that, the script should be successful:
+
+```shell
+Warning: Detected changes to resource pvc-279e8c3e-bfb0-4233-8899-77b5b178c08c which is currently being deleted.
+volumeattachment.longhorn.io/pvc-279e8c3e-bfb0-4233-8899-77b5b178c08c configured
+No resources found
+customresourcedefinition.apiextensions.k8s.io "volumeattachments.longhorn.io" deleted
+```
+
 ---
 Please see [link](https://github.com/longhorn/longhorn) for more information.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/longhorn/longhorn/issues/9116

#### What this PR does / why we need it:

This is an addendum to the section on forcible cleanup.  The user may hit Longhorn webhooks that are still registered although the services have been uninstalled.  Here's how to fix that.

#### Special notes for your reviewer:

#### Additional documentation or context
