### PR TITLE
doc(volumes): clarify manual how-to for RWX volume expansion and add …

### DIFF
--- a/content/docs/1.5.4/volumes-and-nodes/expansion.md
+++ b/content/docs/1.5.4/volumes-and-nodes/expansion.md
@@ -125,10 +125,30 @@ If you cannot enable it but still prefer to do online expansion, you can:
 
 #### RWX volume
 
-Currently, Longhorn is unable to expand the filesystem (NFS) for RWX volumes. - If you decide to expand a RWX volume manually, you can:
+Longhorn currently does not support fully automatic expansion of the filesystem (NFS) for RWX volumes.  You can expand the filesystem manually using one of the following methods:
 
+##### Online
 1. Expand the block device of the RWX volume via PVC or UI.
-2. Figure out the share manager pod of the RWX volume then execute the filesystem expansion command. The share manager pod is typically named as `share-manager-<volume name>`.
+2. Identify the Share Manager pod of the RWX volume (typically named `share-manager-<volume name>`), and then run the filesystem expansion command in it.
     ```shell
     kubectl -n longhorn-system exec -it <the share manager pod> -- resize2fs /dev/longhorn/<volume name>
     ```
+
+> **Important**:  
+> Online expansion is possible only for `ext4` volumes. Attempts to manually expand `xfs` volumes with `xfs_growfs` may initially appear to be successful, but issues occur when the workload is scaled up and the volume is reattached. In particular, the pods become stuck in the `ContainerCreating` state, and the logs show an error message about attempts to mount the filesystem.
+
+##### Offline
+
+1. Detach the RWX volume by scaling down the workload to `replicas=0`. Ensure that the volume is fully detached.
+
+1. After the scale command returns, run the following command and verify that the state is `detached`.
+    ```shell
+    kubectl -n longhorn-system get volume <volume-name>
+    ```
+1. Expand the block device using either the PVC or the Longhorn UI.
+
+1. Scale up the workload.
+
+The reattached volume will have the expanded size.
+
+

--- a/content/docs/1.5.5/volumes-and-nodes/expansion.md
+++ b/content/docs/1.5.5/volumes-and-nodes/expansion.md
@@ -125,10 +125,30 @@ If you cannot enable it but still prefer to do online expansion, you can:
 
 #### RWX volume
 
-Currently, Longhorn is unable to expand the filesystem (NFS) for RWX volumes. - If you decide to expand a RWX volume manually, you can:
+Longhorn currently does not support fully automatic expansion of the filesystem (NFS) for RWX volumes.  You can expand the filesystem manually using one of the following methods:
 
+##### Online
 1. Expand the block device of the RWX volume via PVC or UI.
-2. Figure out the share manager pod of the RWX volume then execute the filesystem expansion command. The share manager pod is typically named as `share-manager-<volume name>`.
+2. Identify the Share Manager pod of the RWX volume (typically named `share-manager-<volume name>`), and then run the filesystem expansion command in it.
     ```shell
     kubectl -n longhorn-system exec -it <the share manager pod> -- resize2fs /dev/longhorn/<volume name>
     ```
+
+> **Important**:  
+> Online expansion is possible only for `ext4` volumes. Attempts to manually expand `xfs` volumes with `xfs_growfs` may initially appear to be successful, but issues occur when the workload is scaled up and the volume is reattached. In particular, the pods become stuck in the `ContainerCreating` state, and the logs show an error message about attempts to mount the filesystem.
+
+##### Offline
+
+1. Detach the RWX volume by scaling down the workload to `replicas=0`. Ensure that the volume is fully detached.
+
+1. After the scale command returns, run the following command and verify that the state is `detached`.
+    ```shell
+    kubectl -n longhorn-system get volume <volume-name>
+    ```
+1. Expand the block device using either the PVC or the Longhorn UI.
+
+1. Scale up the workload.
+
+The reattached volume will have the expanded size.
+
+

--- a/content/docs/1.5.6/volumes-and-nodes/expansion.md
+++ b/content/docs/1.5.6/volumes-and-nodes/expansion.md
@@ -125,10 +125,30 @@ If you cannot enable it but still prefer to do online expansion, you can:
 
 #### RWX volume
 
-Currently, Longhorn is unable to expand the filesystem (NFS) for RWX volumes. - If you decide to expand a RWX volume manually, you can:
+Longhorn currently does not support fully automatic expansion of the filesystem (NFS) for RWX volumes.  You can expand the filesystem manually using one of the following methods:
 
+##### Online
 1. Expand the block device of the RWX volume via PVC or UI.
-2. Figure out the share manager pod of the RWX volume then execute the filesystem expansion command. The share manager pod is typically named as `share-manager-<volume name>`.
+2. Identify the Share Manager pod of the RWX volume (typically named `share-manager-<volume name>`), and then run the filesystem expansion command in it.
     ```shell
     kubectl -n longhorn-system exec -it <the share manager pod> -- resize2fs /dev/longhorn/<volume name>
     ```
+
+> **Important**:  
+> Online expansion is possible only for `ext4` volumes. Attempts to manually expand `xfs` volumes with `xfs_growfs` may initially appear to be successful, but issues occur when the workload is scaled up and the volume is reattached. In particular, the pods become stuck in the `ContainerCreating` state, and the logs show an error message about attempts to mount the filesystem.
+
+##### Offline
+
+1. Detach the RWX volume by scaling down the workload to `replicas=0`. Ensure that the volume is fully detached.
+
+1. After the scale command returns, run the following command and verify that the state is `detached`.
+    ```shell
+    kubectl -n longhorn-system get volume <volume-name>
+    ```
+1. Expand the block device using either the PVC or the Longhorn UI.
+
+1. Scale up the workload.
+
+The reattached volume will have the expanded size.
+
+

--- a/content/docs/1.6.0/nodes-and-volumes/volumes/expansion.md
+++ b/content/docs/1.6.0/nodes-and-volumes/volumes/expansion.md
@@ -125,10 +125,30 @@ If you cannot enable it but still prefer to do online expansion, you can:
 
 #### RWX volume
 
-Currently, Longhorn is unable to expand the filesystem (NFS) for RWX volumes. - If you decide to expand a RWX volume manually, you can:
+Longhorn currently does not support fully automatic expansion of the filesystem (NFS) for RWX volumes.  You can expand the filesystem manually using one of the following methods:
 
+##### Online
 1. Expand the block device of the RWX volume via PVC or UI.
-2. Figure out the share manager pod of the RWX volume then execute the filesystem expansion command. The share manager pod is typically named as `share-manager-<volume name>`.
+2. Identify the Share Manager pod of the RWX volume (typically named `share-manager-<volume name>`), and then run the filesystem expansion command in it.
     ```shell
     kubectl -n longhorn-system exec -it <the share manager pod> -- resize2fs /dev/longhorn/<volume name>
     ```
+
+> **Important**:  
+> Online expansion is possible only for `ext4` volumes. Attempts to manually expand `xfs` volumes with `xfs_growfs` may initially appear to be successful, but issues occur when the workload is scaled up and the volume is reattached. In particular, the pods become stuck in the `ContainerCreating` state, and the logs show an error message about attempts to mount the filesystem.
+
+##### Offline
+
+1. Detach the RWX volume by scaling down the workload to `replicas=0`. Ensure that the volume is fully detached.
+
+1. After the scale command returns, run the following command and verify that the state is `detached`.
+    ```shell
+    kubectl -n longhorn-system get volume <volume-name>
+    ```
+1. Expand the block device using either the PVC or the Longhorn UI.
+
+1. Scale up the workload.
+
+The reattached volume will have the expanded size.
+
+

--- a/content/docs/1.6.1/nodes-and-volumes/volumes/expansion.md
+++ b/content/docs/1.6.1/nodes-and-volumes/volumes/expansion.md
@@ -125,10 +125,30 @@ If you cannot enable it but still prefer to do online expansion, you can:
 
 #### RWX volume
 
-Currently, Longhorn is unable to expand the filesystem (NFS) for RWX volumes. - If you decide to expand a RWX volume manually, you can:
+Longhorn currently does not support fully automatic expansion of the filesystem (NFS) for RWX volumes.  You can expand the filesystem manually using one of the following methods:
 
+##### Online
 1. Expand the block device of the RWX volume via PVC or UI.
-2. Figure out the share manager pod of the RWX volume then execute the filesystem expansion command. The share manager pod is typically named as `share-manager-<volume name>`.
+2. Identify the Share Manager pod of the RWX volume (typically named `share-manager-<volume name>`), and then run the filesystem expansion command in it.
     ```shell
     kubectl -n longhorn-system exec -it <the share manager pod> -- resize2fs /dev/longhorn/<volume name>
     ```
+
+> **Important**:  
+> Online expansion is possible only for `ext4` volumes. Attempts to manually expand `xfs` volumes with `xfs_growfs` may initially appear to be successful, but issues occur when the workload is scaled up and the volume is reattached. In particular, the pods become stuck in the `ContainerCreating` state, and the logs show an error message about attempts to mount the filesystem.
+
+##### Offline
+
+1. Detach the RWX volume by scaling down the workload to `replicas=0`. Ensure that the volume is fully detached.
+
+1. After the scale command returns, run the following command and verify that the state is `detached`.
+    ```shell
+    kubectl -n longhorn-system get volume <volume-name>
+    ```
+1. Expand the block device using either the PVC or the Longhorn UI.
+
+1. Scale up the workload.
+
+The reattached volume will have the expanded size.
+
+

--- a/content/docs/1.6.2/nodes-and-volumes/volumes/expansion.md
+++ b/content/docs/1.6.2/nodes-and-volumes/volumes/expansion.md
@@ -125,10 +125,30 @@ If you cannot enable it but still prefer to do online expansion, you can:
 
 #### RWX volume
 
-Currently, Longhorn is unable to expand the filesystem (NFS) for RWX volumes. - If you decide to expand a RWX volume manually, you can:
+Longhorn currently does not support fully automatic expansion of the filesystem (NFS) for RWX volumes.  You can expand the filesystem manually using one of the following methods:
 
+##### Online
 1. Expand the block device of the RWX volume via PVC or UI.
-2. Figure out the share manager pod of the RWX volume then execute the filesystem expansion command. The share manager pod is typically named as `share-manager-<volume name>`.
+2. Identify the Share Manager pod of the RWX volume (typically named `share-manager-<volume name>`), and then run the filesystem expansion command in it.
     ```shell
     kubectl -n longhorn-system exec -it <the share manager pod> -- resize2fs /dev/longhorn/<volume name>
     ```
+
+> **Important**:  
+> Online expansion is possible only for `ext4` volumes. Attempts to manually expand `xfs` volumes with `xfs_growfs` may initially appear to be successful, but issues occur when the workload is scaled up and the volume is reattached. In particular, the pods become stuck in the `ContainerCreating` state, and the logs show an error message about attempts to mount the filesystem.
+
+##### Offline
+
+1. Detach the RWX volume by scaling down the workload to `replicas=0`. Ensure that the volume is fully detached.
+
+1. After the scale command returns, run the following command and verify that the state is `detached`.
+    ```shell
+    kubectl -n longhorn-system get volume <volume-name>
+    ```
+1. Expand the block device using either the PVC or the Longhorn UI.
+
+1. Scale up the workload.
+
+The reattached volume will have the expanded size.
+
+

--- a/content/docs/1.6.3/nodes-and-volumes/volumes/expansion.md
+++ b/content/docs/1.6.3/nodes-and-volumes/volumes/expansion.md
@@ -125,10 +125,30 @@ If you cannot enable it but still prefer to do online expansion, you can:
 
 #### RWX volume
 
-Currently, Longhorn is unable to expand the filesystem (NFS) for RWX volumes. - If you decide to expand a RWX volume manually, you can:
+Longhorn currently does not support fully automatic expansion of the filesystem (NFS) for RWX volumes.  You can expand the filesystem manually using one of the following methods:
 
+##### Online
 1. Expand the block device of the RWX volume via PVC or UI.
-2. Figure out the share manager pod of the RWX volume then execute the filesystem expansion command. The share manager pod is typically named as `share-manager-<volume name>`.
+2. Identify the Share Manager pod of the RWX volume (typically named `share-manager-<volume name>`), and then run the filesystem expansion command in it.
     ```shell
     kubectl -n longhorn-system exec -it <the share manager pod> -- resize2fs /dev/longhorn/<volume name>
     ```
+
+> **Important**:  
+> Online expansion is possible only for `ext4` volumes. Attempts to manually expand `xfs` volumes with `xfs_growfs` may initially appear to be successful, but issues occur when the workload is scaled up and the volume is reattached. In particular, the pods become stuck in the `ContainerCreating` state, and the logs show an error message about attempts to mount the filesystem.
+
+##### Offline
+
+1. Detach the RWX volume by scaling down the workload to `replicas=0`. Ensure that the volume is fully detached.
+
+1. After the scale command returns, run the following command and verify that the state is `detached`.
+    ```shell
+    kubectl -n longhorn-system get volume <volume-name>
+    ```
+1. Expand the block device using either the PVC or the Longhorn UI.
+
+1. Scale up the workload.
+
+The reattached volume will have the expanded size.
+
+

--- a/content/docs/1.7.0/nodes-and-volumes/volumes/expansion.md
+++ b/content/docs/1.7.0/nodes-and-volumes/volumes/expansion.md
@@ -125,10 +125,30 @@ If you cannot enable it but still prefer to do online expansion, you can:
 
 #### RWX volume
 
-Currently, Longhorn is unable to expand the filesystem (NFS) for RWX volumes. - If you decide to expand a RWX volume manually, you can:
+Longhorn currently does not support fully automatic expansion of the filesystem (NFS) for RWX volumes.  You can expand the filesystem manually using one of the following methods:
 
+##### Online
 1. Expand the block device of the RWX volume via PVC or UI.
-2. Figure out the share manager pod of the RWX volume then execute the filesystem expansion command. The share manager pod is typically named as `share-manager-<volume name>`.
+2. Identify the Share Manager pod of the RWX volume (typically named `share-manager-<volume name>`), and then run the filesystem expansion command in it.
     ```shell
     kubectl -n longhorn-system exec -it <the share manager pod> -- resize2fs /dev/longhorn/<volume name>
     ```
+
+> **Important**:  
+> Online expansion is possible only for `ext4` volumes. Attempts to manually expand `xfs` volumes with `xfs_growfs` may initially appear to be successful, but issues occur when the workload is scaled up and the volume is reattached. In particular, the pods become stuck in the `ContainerCreating` state, and the logs show an error message about attempts to mount the filesystem.
+
+##### Offline
+
+1. Detach the RWX volume by scaling down the workload to `replicas=0`. Ensure that the volume is fully detached.
+
+1. After the scale command returns, run the following command and verify that the state is `detached`.
+    ```shell
+    kubectl -n longhorn-system get volume <volume-name>
+    ```
+1. Expand the block device using either the PVC or the Longhorn UI.
+
+1. Scale up the workload.
+
+The reattached volume will have the expanded size.
+
+


### PR DESCRIPTION
…caveat

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/longhorn/longhorn/issues/6216

#### What this PR does / why we need it:
Be more explicit about the steps to grow an RWX volume. Note that online expansion can't be applied to XFS fsType.

#### Special notes for your reviewer:
This PR replaces https://github.com/longhorn/website/pull/942

#### Additional documentation or context
