### PR TITLE
Remove downgrade examples from upgrade path table

### DIFF
--- a/content/docs/1.5.0/deploy/upgrade/_index.md
+++ b/content/docs/1.5.0/deploy/upgrade/_index.md
@@ -28,8 +28,6 @@ The following table outlines the supported upgrade paths.
   |  x.y[^lastMinorVersion].*      |  (x+1).y.*  |   ✓    |  v1.30.0 to  v2.0.0  |
   |  x.(y-1).*  |  x.(y+1).*  |   X    |  v1.3.3  to  v1.5.0  |
   |  x.(y-2).*  |  x.(y+1).*  |   X    |  v1.2.6  to  v1.5.0  |
-  |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.0  |
-  |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
 [^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. For example, if v1.3.0 is the last minor version before v2.0, you can upgrade from any patch version of v1.3.0 to any patch version of v2.0.
 

--- a/content/docs/1.5.1/deploy/upgrade/_index.md
+++ b/content/docs/1.5.1/deploy/upgrade/_index.md
@@ -22,8 +22,6 @@ In addition, Longhorn disallows downgrading to any previous version to prevent u
   |  x.y[^lastMinorVersion].*      |  (x+1).y.*  |   ✓    |  v1.30.0 to  v2.0.0  |
   |  x.(y-1).*  |  x.(y+1).*  |   X    |  v1.3.3  to  v1.5.1  |
   |  x.(y-2).*  |  x.(y+1).*  |   X    |  v1.2.6  to  v1.5.1  |
-  |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.1  |
-  |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
 [^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. (For example, v1.30.* is allowed to upgrade to v2.0.*, given that v1.30 is the last minor release branch before 2.0.)
 

--- a/content/docs/1.5.2/deploy/upgrade/_index.md
+++ b/content/docs/1.5.2/deploy/upgrade/_index.md
@@ -22,8 +22,6 @@ In addition, Longhorn disallows downgrading to any previous version to prevent u
   |  x.y[^lastMinorVersion].*      |  (x+1).y.*  |   ✓    |  v1.30.0 to  v2.0.0  |
   |  x.(y-1).*  |  x.(y+1).*  |   X    |  v1.3.3  to  v1.5.1  |
   |  x.(y-2).*  |  x.(y+1).*  |   X    |  v1.2.6  to  v1.5.1  |
-  |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.1  |
-  |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
 [^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. (For example, v1.30.* is allowed to upgrade to v2.0.*, given that v1.30 is the last minor release branch before 2.0.)
 

--- a/content/docs/1.5.3/deploy/upgrade/_index.md
+++ b/content/docs/1.5.3/deploy/upgrade/_index.md
@@ -22,8 +22,6 @@ In addition, Longhorn disallows downgrading to any previous version to prevent u
   |  x.y[^lastMinorVersion].*      |  (x+1).y.*  |   ✓    |  v1.30.0 to  v2.0.0  |
   |  x.(y-1).*  |  x.(y+1).*  |   X    |  v1.3.3  to  v1.5.1  |
   |  x.(y-2).*  |  x.(y+1).*  |   X    |  v1.2.6  to  v1.5.1  |
-  |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.1  |
-  |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
 [^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. (For example, v1.30.* is allowed to upgrade to v2.0.*, given that v1.30 is the last minor release branch before 2.0.)
 

--- a/content/docs/1.5.4/deploy/upgrade/_index.md
+++ b/content/docs/1.5.4/deploy/upgrade/_index.md
@@ -22,8 +22,6 @@ In addition, Longhorn disallows downgrading to any previous version to prevent u
   |  x.y[^lastMinorVersion].*      |  (x+1).y.*  |   ✓    |  v1.30.0 to  v2.0.0  |
   |  x.(y-1).*  |  x.(y+1).*  |   X    |  v1.3.3  to  v1.5.1  |
   |  x.(y-2).*  |  x.(y+1).*  |   X    |  v1.2.6  to  v1.5.1  |
-  |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.1  |
-  |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
 [^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. (For example, v1.30.* is allowed to upgrade to v2.0.*, given that v1.30 is the last minor release branch before 2.0.)
 

--- a/content/docs/1.5.5/deploy/upgrade/_index.md
+++ b/content/docs/1.5.5/deploy/upgrade/_index.md
@@ -22,8 +22,6 @@ In addition, Longhorn disallows downgrading to any previous version to prevent u
   |  x.y[^lastMinorVersion].*      |  (x+1).y.*  |   ✓    |  v1.30.0 to  v2.0.0  |
   |  x.(y-1).*  |  x.(y+1).*  |   X    |  v1.3.3  to  v1.5.1  |
   |  x.(y-2).*  |  x.(y+1).*  |   X    |  v1.2.6  to  v1.5.1  |
-  |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.1  |
-  |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
 [^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. (For example, v1.30.* is allowed to upgrade to v2.0.*, given that v1.30 is the last minor release branch before 2.0.)
 

--- a/content/docs/1.5.6/deploy/upgrade/_index.md
+++ b/content/docs/1.5.6/deploy/upgrade/_index.md
@@ -22,8 +22,6 @@ In addition, Longhorn disallows downgrading to any previous version to prevent u
   |  x.y[^lastMinorVersion].*      |  (x+1).y.*  |   ✓    |  v1.30.0 to  v2.0.0  |
   |  x.(y-1).*  |  x.(y+1).*  |   X    |  v1.3.3  to  v1.5.1  |
   |  x.(y-2).*  |  x.(y+1).*  |   X    |  v1.2.6  to  v1.5.1  |
-  |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.1  |
-  |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
 [^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. (For example, v1.30.* is allowed to upgrade to v2.0.*, given that v1.30 is the last minor release branch before 2.0.)
 

--- a/content/docs/1.6.0/deploy/upgrade/_index.md
+++ b/content/docs/1.6.0/deploy/upgrade/_index.md
@@ -29,8 +29,6 @@ The following table outlines the supported upgrade paths.
   |  x.y[^lastMinorVersion].*      |  (x+1).y.*  |   ✓    |  v1.30.0 to  v2.0.0  |
   |  x.(y-1).*  |  x.(y+1).*  |   X    |  v1.3.3  to  v1.5.1  |
   |  x.(y-2).*  |  x.(y+1).*  |   X    |  v1.2.6  to  v1.5.1  |
-  |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.1  |
-  |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
 [^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. For example, if v1.3.0 is the last minor version before v2.0, you can upgrade from any patch version of v1.3.0 to any patch version of v2.0.
 

--- a/content/docs/1.6.1/deploy/upgrade/_index.md
+++ b/content/docs/1.6.1/deploy/upgrade/_index.md
@@ -29,8 +29,6 @@ The following table outlines the supported upgrade paths.
   |  x.y[^lastMinorVersion].*      |  (x+1).y.*  |   ✓    |  v1.30.0 to  v2.0.0  |
   |  x.(y-1).*  |  x.(y+1).*  |   X    |  v1.3.3  to  v1.5.1  |
   |  x.(y-2).*  |  x.(y+1).*  |   X    |  v1.2.6  to  v1.5.1  |
-  |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.1  |
-  |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
 [^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. For example, if v1.3.0 is the last minor version before v2.0, you can upgrade from any patch version of v1.3.0 to any patch version of v2.0.
 

--- a/content/docs/1.6.2/deploy/upgrade/_index.md
+++ b/content/docs/1.6.2/deploy/upgrade/_index.md
@@ -29,8 +29,6 @@ The following table outlines the supported upgrade paths.
   |  x.y[^lastMinorVersion].*      |  (x+1).y.*  |   ✓    |  v1.30.0 to  v2.0.0  |
   |  x.(y-1).*  |  x.(y+1).*  |   X    |  v1.3.3  to  v1.5.1  |
   |  x.(y-2).*  |  x.(y+1).*  |   X    |  v1.2.6  to  v1.5.1  |
-  |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.1  |
-  |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
 [^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. For example, if v1.3.0 is the last minor version before v2.0, you can upgrade from any patch version of v1.3.0 to any patch version of v2.0.
 

--- a/content/docs/1.6.3/deploy/upgrade/_index.md
+++ b/content/docs/1.6.3/deploy/upgrade/_index.md
@@ -29,8 +29,6 @@ The following table outlines the supported upgrade paths.
   |  x.y[^lastMinorVersion].*      |  (x+1).y.*  |   ✓    |  v1.30.0 to  v2.0.0  |
   |  x.(y-1).*  |  x.(y+1).*  |   X    |  v1.3.3  to  v1.5.1  |
   |  x.(y-2).*  |  x.(y+1).*  |   X    |  v1.2.6  to  v1.5.1  |
-  |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.1  |
-  |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
 [^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. For example, if v1.3.0 is the last minor version before v2.0, you can upgrade from any patch version of v1.3.0 to any patch version of v2.0.
 

--- a/content/docs/1.7.0/deploy/upgrade/_index.md
+++ b/content/docs/1.7.0/deploy/upgrade/_index.md
@@ -29,8 +29,6 @@ The following table outlines the supported upgrade paths.
   |  x.y[^lastMinorVersion].*      |  (x+1).y.*  |   ✓    |  v1.30.0 to  v2.0.0  |
   |  x.(y-1).*  |  x.(y+1).*  |   X    |  v1.3.3  to  v1.5.1  |
   |  x.(y-2).*  |  x.(y+1).*  |   X    |  v1.2.6  to  v1.5.1  |
-  |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.1  |
-  |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
 [^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. For example, if v1.3.0 is the last minor version before v2.0, you can upgrade from any patch version of v1.3.0 to any patch version of v2.0.
 

--- a/content/docs/1.7.1/deploy/upgrade/_index.md
+++ b/content/docs/1.7.1/deploy/upgrade/_index.md
@@ -29,8 +29,6 @@ The following table outlines the supported upgrade paths.
   |  x.y[^lastMinorVersion].*      |  (x+1).y.*  |   ✓    |  v1.30.0 to  v2.0.0  |
   |  x.(y-1).*  |  x.(y+1).*  |   X    |  v1.3.3  to  v1.5.1  |
   |  x.(y-2).*  |  x.(y+1).*  |   X    |  v1.2.6  to  v1.5.1  |
-  |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.1  |
-  |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
 [^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. For example, if v1.3.0 is the last minor version before v2.0, you can upgrade from any patch version of v1.3.0 to any patch version of v2.0.
 

--- a/content/docs/1.8.0/deploy/upgrade/_index.md
+++ b/content/docs/1.8.0/deploy/upgrade/_index.md
@@ -29,8 +29,6 @@ The following table outlines the supported upgrade paths.
   |  x.y[^lastMinorVersion].*      |  (x+1).y.*  |   ✓    |  v1.30.0 to  v2.0.0  |
   |  x.(y-1).*  |  x.(y+1).*  |   X    |  v1.3.3  to  v1.5.1  |
   |  x.(y-2).*  |  x.(y+1).*  |   X    |  v1.2.6  to  v1.5.1  |
-  |  x.y.*      |  x.(y-1).*  |   X    |  v1.6.0  to  v1.5.1  |
-  |  x.y.*      |  x.y.(*-1)  |   X    |  v1.5.1  to  v1.5.0  |
 
 [^lastMinorVersion]: Longhorn only allows upgrades from any patch version of the last minor release before the new major version. For example, if v1.3.0 is the last minor version before v2.0, you can upgrade from any patch version of v1.3.0 to any patch version of v2.0.
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue #9291

#### What this PR does / why we need it:
This PR removes downgrade examples from the table that explains the supported upgrade paths. Longhorn does not support downgrades at all so those examples do not provide any value to users and may even cause confusion.