### PR TITLE
doc(1.8.0): add DR volumes support for v2 data engine

### DIFF
--- a/content/docs/1.8.0/important-notes/_index.md
+++ b/content/docs/1.8.0/important-notes/_index.md
@@ -34,6 +34,7 @@ Please see [here](https://github.com/longhorn/longhorn/releases/tag/v{{< current
   - [Linux Kernel on Longhorn Nodes](#linux-kernel-on-longhorn-nodes)
   - [Snapshot Creation Time As Shown in the UI Occasionally Changes](#snapshot-creation-time-as-shown-in-the-ui-occasionally-changes)
   - [Unable To Revert a Volume to a Snapshot Created Before Longhorn v1.7.0](#unable-to-revert-a-volume-to-a-snapshot-created-before-longhorn-v170)
+  - [Disaster Recovery Volumes](#disaster-recovery-volumes)
 
 ## Deprecation
 
@@ -226,6 +227,6 @@ Snapshots created before Longhorn v1.7.0 may change occasionally. This issue ari
 
 Reverting a volume to a snapshot created before Longhorn v1.7.0 is not supported due to an incorrect UserCreated flag set on the snapshot. The workaround is to back up the existing snapshots before upgrading to Longhorn v1.7.0 and restore them if needed. The bug is fixed in v1.7.0, and more information can be found [here](https://github.com/longhorn/longhorn/issues/9054).
 
+### Disaster Recovery Volumes
 
-
-
+Disaster recovery volumes are supported from Longhorn v1.8.0.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#6613

#### What this PR does / why we need it:

Add DR volume support for the v2 data engine in the important note.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
