### PR TITLE
doc(metric): add volume read only metric

### DIFF
--- a/content/docs/1.8.0/monitoring/metrics.md
+++ b/content/docs/1.8.0/monitoring/metrics.md
@@ -16,6 +16,7 @@ weight: 3
 | longhorn_volume_write_iops | Write IOPS of this volume | longhorn_volume_write_iops{pvc_namespace="default",node="worker-2",pvc="testvol",volume="testvol"} 100 |
 | longhorn_volume_read_latency | Read latency of this volume (ns) | longhorn_volume_read_latency{pvc_namespace="default",node="worker-2",pvc="testvol",volume="testvol"} 100000 |
 | longhorn_volume_write_latency | Write latency of this volume (ns) | longhorn_volume_write_latency{pvc_namespace="default",node="worker-2",pvc="testvol",volume="testvol"} 100000 |
+| longhorn_volume_file_system_read_only | This metric indicates that the volume is now in read-only mode. The metric is either 1 or no record for each volume | longhorn_volume_file_system_read_only{node="worker-2",pvc="testvol",pvc_namespace="default",volume="testvol"} 1
 
 ## Node
 


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/8508

Export the metrics in the following form
- metric name: `longhorn_volume_file_system_read_only`
- type: gauge
- if the volume becomes read-only, it has metric value 1 with the corresponding labels
    - So you know which volume is in read-only mode now
    - You can sum up the metrics to see how many volumes are in read-only mode now 
```
# HELP longhorn_volume_file_system_read_only Volume whose mount point is in read-only mode
# TYPE longhorn_volume_file_system_read_only gauge
longhorn_volume_file_system_read_only{node="kworker1",pvc="nginx",pvc_namespace="default",volume="pvc-3a7a208b-c8c9-46a9-b2ce-4c5f740c8673"} 1
```

Note:
If Longhorn remounts the mount point to read-write successfully, the metrics will be cleaned up.
The metric is either 1 or no record for each volume