### PR TITLE
docs(rwx): fix mistaken note about auto-deletion setting for 1.6.4

### DIFF
--- a/content/docs/1.6.4/references/settings.md
+++ b/content/docs/1.6.4/references/settings.md
@@ -147,7 +147,6 @@ If disabled, Longhorn will not delete the workload pod that is managed by a cont
 
 > **Note:** This setting doesn't apply to below cases.
 > - The workload pods don't have a controller; Longhorn never deletes them.
-> - The volumes used by workloads are RWX, because the Longhorn share manager, which provides the RWX NFS service, has its own resilience mechanism to ensure availability until the volume gets reattached without relying on the pod lifecycle to trigger volume reattachment. For details, see [here](../../nodes-and-volumes/volumes/rwx-volumes).
 
 #### Automatic Salvage
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/longhorn/longhorn/issues/9415

#### What this PR does / why we need it:

Correct a statement about Longhorn restart of RWX workload pods when auto-delete-pod-when-volume-detached-unexpectedly is true.  Apply to the 1.6.4 release docs, which copied the un-corrected content.

#### Special notes for your reviewer:

Same change as in https://github.com/longhorn/website/pull/988 for the other releases.

#### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Comprehensive updates to the `settings.md` documentation for Longhorn, including new and modified configuration options.
	- Enhanced clarity on node drain policies, automatic cleanup settings, volume and replica management, data engine options, backup and restore settings, scheduling policies, and danger zone settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->