### PR TITLE
doc(1.8.0): system backup's if-not-present volume backup policy

### DIFF
--- a/content/docs/1.8.0/advanced-resources/system-backup-restore/backup-longhorn-system.md
+++ b/content/docs/1.8.0/advanced-resources/system-backup-restore/backup-longhorn-system.md
@@ -61,7 +61,7 @@ You can create a Longhorn system backup using the Longhorn UI. Or with the `kube
 
 #### Volume Backup Policy
 The Longhorn system backup offers the following volume backup policies:
- - `if-not-present`: Longhorn will create a backup for volumes that currently lack a backup.
+ - `if-not-present`: Longhorn will create a backup for volumes that either lack an existing backup or have an outdated latest backup.
  - `always`: Longhorn will create a backup for all volumes, regardless of their existing backups.
  - `disabled`: Longhorn will not create any backups for volumes.
 

--- a/content/docs/1.8.0/important-notes/_index.md
+++ b/content/docs/1.8.0/important-notes/_index.md
@@ -228,6 +228,12 @@ Starting with v{{< current-version >}}, Longhorn handles backup-related custom r
 
 For more information, see [#9530](https://github.com/longhorn/longhorn/issues/9530).
 
+## System Backup And Restore
+
+### Volume Backup Policy
+
+Since Longhorn v1.8.0, the `if-not-present` volume backup policy now ensures the latest backup contains the most recent data. If the latest backup is outdated, Longhorn will create a new backup for the volume.
+
 ## V2 Data Engine
 
 ### Longhorn System Upgrade


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#6027

#### What this PR does / why we need it:

- Update important note.
- Update the policy description.

#### Special notes for your reviewer:

`None`

#### Additional documentation or context

`None`
