### PR TITLE
Update longhorn-ingress.md. Add missing ingressClassName to ingress .yaml

### DIFF
--- a/content/docs/1.6.3/deploy/accessing-the-ui/longhorn-ingress.md
+++ b/content/docs/1.6.3/deploy/accessing-the-ui/longhorn-ingress.md
@@ -91,6 +91,7 @@ metadata:
     # message to display with an appropriate context why the authentication is required
     nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required '
 spec:
+  ingressClassName: nginx
   rules:
   - http:
       paths:

--- a/content/docs/1.6.3/deploy/accessing-the-ui/longhorn-ingress.md
+++ b/content/docs/1.6.3/deploy/accessing-the-ui/longhorn-ingress.md
@@ -36,6 +36,7 @@ Authentication is not enabled by default for kubectl and Helm installations. In 
         # custom max body size for file uploading like backing image uploading
         nginx.ingress.kubernetes.io/proxy-body-size: 10000m
     spec:
+      ingressClassName: nginx
       rules:
       - http:
           paths:

--- a/content/docs/1.6.4/deploy/accessing-the-ui/longhorn-ingress.md
+++ b/content/docs/1.6.4/deploy/accessing-the-ui/longhorn-ingress.md
@@ -36,6 +36,7 @@ Authentication is not enabled by default for kubectl and Helm installations. In 
         # custom max body size for file uploading like backing image uploading
         nginx.ingress.kubernetes.io/proxy-body-size: 10000m
     spec:
+      ingressClassName: nginx
       rules:
       - http:
           paths:

--- a/content/docs/1.7.0/deploy/accessing-the-ui/longhorn-ingress.md
+++ b/content/docs/1.7.0/deploy/accessing-the-ui/longhorn-ingress.md
@@ -36,6 +36,7 @@ Authentication is not enabled by default for kubectl and Helm installations. In 
         # custom max body size for file uploading like backing image uploading
         nginx.ingress.kubernetes.io/proxy-body-size: 10000m
     spec:
+      ingressClassName: nginx
       rules:
       - http:
           paths:

--- a/content/docs/1.7.1/deploy/accessing-the-ui/longhorn-ingress.md
+++ b/content/docs/1.7.1/deploy/accessing-the-ui/longhorn-ingress.md
@@ -36,6 +36,7 @@ Authentication is not enabled by default for kubectl and Helm installations. In 
         # custom max body size for file uploading like backing image uploading
         nginx.ingress.kubernetes.io/proxy-body-size: 10000m
     spec:
+      ingressClassName: nginx
       rules:
       - http:
           paths:

--- a/content/docs/1.7.2/deploy/accessing-the-ui/longhorn-ingress.md
+++ b/content/docs/1.7.2/deploy/accessing-the-ui/longhorn-ingress.md
@@ -36,6 +36,7 @@ Authentication is not enabled by default for kubectl and Helm installations. In 
         # custom max body size for file uploading like backing image uploading
         nginx.ingress.kubernetes.io/proxy-body-size: 10000m
     spec:
+      ingressClassName: nginx
       rules:
       - http:
           paths:

--- a/content/docs/1.7.3/deploy/accessing-the-ui/longhorn-ingress.md
+++ b/content/docs/1.7.3/deploy/accessing-the-ui/longhorn-ingress.md
@@ -36,6 +36,7 @@ Authentication is not enabled by default for kubectl and Helm installations. In 
         # custom max body size for file uploading like backing image uploading
         nginx.ingress.kubernetes.io/proxy-body-size: 10000m
     spec:
+      ingressClassName: nginx
       rules:
       - http:
           paths:

--- a/content/docs/1.8.0/deploy/accessing-the-ui/longhorn-ingress.md
+++ b/content/docs/1.8.0/deploy/accessing-the-ui/longhorn-ingress.md
@@ -36,6 +36,7 @@ Authentication is not enabled by default for kubectl and Helm installations. In 
         # custom max body size for file uploading like backing image uploading
         nginx.ingress.kubernetes.io/proxy-body-size: 10000m
     spec:
+      ingressClassName: nginx
       rules:
       - http:
           paths:


### PR DESCRIPTION
Add missing ingressClassName

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context

After going through Longhorn's documentation, I came across this code snippet to setup Longhorn ingress. It the text above the code snippet, it says it's using nginx as Ingress Controller but the Longhorn Ingress definition is missing the ingressClassName property, which is key to make it work.