### PR TITLE
docs: correct module name from nvme-tcp to nvme_tcp

### DIFF
--- a/content/docs/1.7.2/v2-data-engine/prerequisites.md
+++ b/content/docs/1.7.2/v2-data-engine/prerequisites.md
@@ -24,12 +24,12 @@ Longhorn nodes must meet the following requirements:
   v6.7 or later is recommended for improved system stability
   > **NOTICE**
   >
-  > Memory corruption may occur on hosts using versions of the Linux kernel earlier than 6.7, as highlighted by this SPDK upstream issue: https://github.com/spdk/spdk/issues/3116#issuecomment-1890984674. In Longhorn environments the kernel panic can be caused by prevalent IO timeouts in communications between the `nvme-tcp` driver and SPDK. Update the Linux kernel on Longhorn nodes to version 6.7 or later to prevent the issue from occurring.
+  > Memory corruption may occur on hosts using versions of the Linux kernel earlier than 6.7, as highlighted by this SPDK upstream issue: https://github.com/spdk/spdk/issues/3116#issuecomment-1890984674. In Longhorn environments the kernel panic can be caused by prevalent IO timeouts in communications between the `nvme_tcp` driver and SPDK. Update the Linux kernel on Longhorn nodes to version 6.7 or later to prevent the issue from occurring.
 
 - Linux kernel modules
   - `vfio_pci`
   - `uio_pci_generic`
-  - `nvme-tcp`
+  - `nvme_tcp`
 
 - Huge page support
   - 2 GiB of 2 MiB-sized pages


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:
The kernel module name 'nvme_tcp' was incorrectly documented as 'nvme-tcp'. 
This commit corrects the module name to ensure consistency with the actual kernel module naming convention.

#### Special notes for your reviewer:

#### Additional documentation or context
