### PR TITLE
Update install-longhornctl.md

### DIFF
--- a/content/docs/1.7.2/advanced-resources/longhornctl/install-longhornctl.md
+++ b/content/docs/1.7.2/advanced-resources/longhornctl/install-longhornctl.md
@@ -11,12 +11,12 @@ weight: 1
    ARCH="amd64"
 
    # Download the release binary.
-   curl -LO "https://github.com/longhorn/cli/releases/download/{{< current-version >}}/longhornctl-linux-${ARCH}"
+   curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version >}}/longhornctl-linux-${ARCH}"
    ```
 1. Validate the binary:
    ```bash
    # Download the checksum for your architecture.
-   curl -LO "https://github.com/longhorn/cli/releases/download/{{< current-version >}}/longhornctl-linux-${ARCH}.sha256"
+   curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version >}}/longhornctl-linux-${ARCH}.sha256"
 
    # Verify the downloaded binary matches the checksum.
    echo "$(cat longhornctl-linux-${ARCH}.sha256 | awk '{print $1}') longhornctl-linux-${ARCH}" | sha256sum --check

--- a/content/docs/1.7.3/advanced-resources/longhornctl/install-longhornctl.md
+++ b/content/docs/1.7.3/advanced-resources/longhornctl/install-longhornctl.md
@@ -11,12 +11,12 @@ weight: 1
    ARCH="amd64"
 
    # Download the release binary.
-   curl -LO "https://github.com/longhorn/cli/releases/download/{{< current-version >}}/longhornctl-linux-${ARCH}"
+   curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version >}}/longhornctl-linux-${ARCH}"
    ```
 1. Validate the binary:
    ```bash
    # Download the checksum for your architecture.
-   curl -LO "https://github.com/longhorn/cli/releases/download/{{< current-version >}}/longhornctl-linux-${ARCH}.sha256"
+   curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version >}}/longhornctl-linux-${ARCH}.sha256"
 
    # Verify the downloaded binary matches the checksum.
    echo "$(cat longhornctl-linux-${ARCH}.sha256 | awk '{print $1}') longhornctl-linux-${ARCH}" | sha256sum --check

--- a/content/docs/1.8.0/advanced-resources/longhornctl/install-longhornctl.md
+++ b/content/docs/1.8.0/advanced-resources/longhornctl/install-longhornctl.md
@@ -11,12 +11,12 @@ weight: 1
    ARCH="amd64"
 
    # Download the release binary.
-   curl -LO "https://github.com/longhorn/cli/releases/download/{{< current-version >}}/longhornctl-linux-${ARCH}"
+   curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version >}}/longhornctl-linux-${ARCH}"
    ```
 1. Validate the binary:
    ```bash
    # Download the checksum for your architecture.
-   curl -LO "https://github.com/longhorn/cli/releases/download/{{< current-version >}}/longhornctl-linux-${ARCH}.sha256"
+   curl -LO "https://github.com/longhorn/cli/releases/download/v{{< current-version >}}/longhornctl-linux-${ARCH}.sha256"
 
    # Verify the downloaded binary matches the checksum.
    echo "$(cat longhornctl-linux-${ARCH}.sha256 | awk '{print $1}') longhornctl-linux-${ARCH}" | sha256sum --check


### PR DESCRIPTION
Fix the downloading link error

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

The download link in the documentation example is not available, and the version number is missing the "v", which causes the command line to fail to run properly.

#### Special notes for your reviewer:

#### Additional documentation or context
