### PR TITLE
doc(1.8.0, 1.7, 1.6): update strict-local restriction

### DIFF
--- a/content/docs/1.6.0/high-availability/data-locality.md
+++ b/content/docs/1.6.0/high-availability/data-locality.md
@@ -19,7 +19,7 @@ Longhorn currently supports two modes for data locality settings:
 
 - `best-effort`: This option instructs Longhorn to try to keep a replica on the same node as the attached volume (workload). Longhorn will not stop the volume, even if it cannot keep a replica local to the attached volume (workload) due to an environment limitation, e.g. not enough disk space, incompatible disk tags, etc.
 
-- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance.
+- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance. This option is incompatible with [ReadWriteMany (RWX) volume](../../nodes-and-volumes/volumes/rwx-volumes).
 
 
 ## How to Set Data Locality For Volumes

--- a/content/docs/1.6.1/high-availability/data-locality.md
+++ b/content/docs/1.6.1/high-availability/data-locality.md
@@ -19,7 +19,7 @@ Longhorn currently supports two modes for data locality settings:
 
 - `best-effort`: This option instructs Longhorn to try to keep a replica on the same node as the attached volume (workload). Longhorn will not stop the volume, even if it cannot keep a replica local to the attached volume (workload) due to an environment limitation, e.g. not enough disk space, incompatible disk tags, etc.
 
-- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance.
+- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance. This option is incompatible with [ReadWriteMany (RWX) volume](../../nodes-and-volumes/volumes/rwx-volumes).
 
 
 ## How to Set Data Locality For Volumes

--- a/content/docs/1.6.2/high-availability/data-locality.md
+++ b/content/docs/1.6.2/high-availability/data-locality.md
@@ -19,7 +19,7 @@ Longhorn currently supports two modes for data locality settings:
 
 - `best-effort`: This option instructs Longhorn to try to keep a replica on the same node as the attached volume (workload). Longhorn will not stop the volume, even if it cannot keep a replica local to the attached volume (workload) due to an environment limitation, e.g. not enough disk space, incompatible disk tags, etc.
 
-- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance.
+- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance. This option is incompatible with [ReadWriteMany (RWX) volume](../../nodes-and-volumes/volumes/rwx-volumes).
 
 
 ## How to Set Data Locality For Volumes

--- a/content/docs/1.6.3/high-availability/data-locality.md
+++ b/content/docs/1.6.3/high-availability/data-locality.md
@@ -19,7 +19,7 @@ Longhorn currently supports two modes for data locality settings:
 
 - `best-effort`: This option instructs Longhorn to try to keep a replica on the same node as the attached volume (workload). Longhorn will not stop the volume, even if it cannot keep a replica local to the attached volume (workload) due to an environment limitation, e.g. not enough disk space, incompatible disk tags, etc.
 
-- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance.
+- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance. This option is incompatible with [ReadWriteMany (RWX) volume](../../nodes-and-volumes/volumes/rwx-volumes).
 
 
 ## How to Set Data Locality For Volumes

--- a/content/docs/1.6.4/high-availability/data-locality.md
+++ b/content/docs/1.6.4/high-availability/data-locality.md
@@ -19,7 +19,7 @@ Longhorn currently supports two modes for data locality settings:
 
 - `best-effort`: This option instructs Longhorn to try to keep a replica on the same node as the attached volume (workload). Longhorn will not stop the volume, even if it cannot keep a replica local to the attached volume (workload) due to an environment limitation, e.g. not enough disk space, incompatible disk tags, etc.
 
-- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance.
+- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance. This option is incompatible with [ReadWriteMany (RWX) volume](../../nodes-and-volumes/volumes/rwx-volumes).
 
 
 ## How to Set Data Locality For Volumes

--- a/content/docs/1.7.0/high-availability/data-locality.md
+++ b/content/docs/1.7.0/high-availability/data-locality.md
@@ -19,7 +19,7 @@ Longhorn currently supports two modes for data locality settings:
 
 - `best-effort`: This option instructs Longhorn to try to keep a replica on the same node as the attached volume (workload). Longhorn will not stop the volume, even if it cannot keep a replica local to the attached volume (workload) due to an environment limitation, e.g. not enough disk space, incompatible disk tags, etc.
 
-- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance.
+- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance. This option is incompatible with [ReadWriteMany (RWX) volume](../../nodes-and-volumes/volumes/rwx-volumes).
 
 
 ## How to Set Data Locality For Volumes

--- a/content/docs/1.7.1/high-availability/data-locality.md
+++ b/content/docs/1.7.1/high-availability/data-locality.md
@@ -19,7 +19,7 @@ Longhorn currently supports two modes for data locality settings:
 
 - `best-effort`: This option instructs Longhorn to try to keep a replica on the same node as the attached volume (workload). Longhorn will not stop the volume, even if it cannot keep a replica local to the attached volume (workload) due to an environment limitation, e.g. not enough disk space, incompatible disk tags, etc.
 
-- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance.
+- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance. This option is incompatible with [ReadWriteMany (RWX) volume](../../nodes-and-volumes/volumes/rwx-volumes).
 
 
 ## How to Set Data Locality For Volumes

--- a/content/docs/1.7.2/high-availability/data-locality.md
+++ b/content/docs/1.7.2/high-availability/data-locality.md
@@ -19,7 +19,7 @@ Longhorn currently supports two modes for data locality settings:
 
 - `best-effort`: This option instructs Longhorn to try to keep a replica on the same node as the attached volume (workload). Longhorn will not stop the volume, even if it cannot keep a replica local to the attached volume (workload) due to an environment limitation, e.g. not enough disk space, incompatible disk tags, etc.
 
-- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance.
+- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance. This option is incompatible with [ReadWriteMany (RWX) volume](../../nodes-and-volumes/volumes/rwx-volumes).
 
 
 ## How to Set Data Locality For Volumes

--- a/content/docs/1.7.3/high-availability/data-locality.md
+++ b/content/docs/1.7.3/high-availability/data-locality.md
@@ -19,7 +19,7 @@ Longhorn currently supports two modes for data locality settings:
 
 - `best-effort`: This option instructs Longhorn to try to keep a replica on the same node as the attached volume (workload). Longhorn will not stop the volume, even if it cannot keep a replica local to the attached volume (workload) due to an environment limitation, e.g. not enough disk space, incompatible disk tags, etc.
 
-- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance.
+- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance. This option is incompatible with [ReadWriteMany (RWX) volume](../../nodes-and-volumes/volumes/rwx-volumes).
 
 
 ## How to Set Data Locality For Volumes

--- a/content/docs/1.8.0/high-availability/data-locality.md
+++ b/content/docs/1.8.0/high-availability/data-locality.md
@@ -19,7 +19,7 @@ Longhorn currently supports two modes for data locality settings:
 
 - `best-effort`: This option instructs Longhorn to try to keep a replica on the same node as the attached volume (workload). Longhorn will not stop the volume, even if it cannot keep a replica local to the attached volume (workload) due to an environment limitation, e.g. not enough disk space, incompatible disk tags, etc.
 
-- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance.
+- `strict-local`: This option enforces Longhorn keep the **only one replica** on the same node as the attached volume, and therefore, it offers higher IOPS and lower latency performance. This option is incompatible with [ReadWriteMany (RWX) volume](../../nodes-and-volumes/volumes/rwx-volumes).
 
 
 ## How to Set Data Locality For Volumes


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#6735

#### What this PR does / why we need it:

Data locality strict-local mode is now incompatible with RWX volume from v1.8.0.

#### Special notes for your reviewer:

#### Additional documentation or context
