### PR TITLE
doc(1.8.0, 1.7, 1.6): online volume expansion for encrypted volumes

### DIFF
--- a/content/docs/1.6.4/advanced-resources/security/volume-encryption.md
+++ b/content/docs/1.6.4/advanced-resources/security/volume-encryption.md
@@ -63,6 +63,8 @@ For more information, see [cryptsetup(8)](https://man7.org/linux/man-pages/man8/
     csi.storage.k8s.io/node-publish-secret-namespace: "longhorn-system"
     csi.storage.k8s.io/node-stage-secret-name: "longhorn-crypto"
     csi.storage.k8s.io/node-stage-secret-namespace: "longhorn-system"
+    csi.storage.k8s.io/node-expand-secret-name: "longhorn-crypto"
+    csi.storage.k8s.io/node-expand-secret-namespace: "longhorn-system"
   ```
 
 - Example of a StorageClass with a volume-specific Secret:
@@ -85,6 +87,8 @@ For more information, see [cryptsetup(8)](https://man7.org/linux/man-pages/man8/
     csi.storage.k8s.io/node-publish-secret-namespace: ${pvc.namespace}
     csi.storage.k8s.io/node-stage-secret-name: ${pvc.name}
     csi.storage.k8s.io/node-stage-secret-namespace: ${pvc.namespace}
+    csi.storage.k8s.io/node-expand-secret-name: ${pvc.name}
+    csi.storage.k8s.io/node-expand-secret-namespace: ${pvc.namespace}
   ```
 
 # Using an Encrypted Volume
@@ -96,7 +100,12 @@ A newly-created PVC remains in the `Pending` state until the associated Secret i
 
 # Filesystem Expansion
 
-Longhorn supports [offline expansion](../../../nodes-and-volumes/volumes/expansion/#encrypted-volume) for encrypted volumes.
+Longhorn supports [both online and offline expansion](../../../nodes-and-volumes/volumes/expansion/#encrypted-volume) for encrypted volumes.
+
+StorageClass parameters are needed to enable online expansion:
+
+- `csi.storage.k8s.io/node-expand-secret-name`
+- `csi.storage.k8s.io/node-expand-secret-namespace`
 
 # History
 - Encryption of volumes in `Filesystem` mode available starting v1.2.0 ([#1859](https://github.com/longhorn/longhorn/issues/1859))

--- a/content/docs/1.6.4/nodes-and-volumes/volumes/expansion.md
+++ b/content/docs/1.6.4/nodes-and-volumes/volumes/expansion.md
@@ -116,7 +116,13 @@ If a volume is reverted to a snapshot with smaller size, the frontend of the vol
 
 #### Encrypted volume
 
-Due to [the upstream limitation](https://kubernetes.io/blog/2022/09/21/kubernetes-1-25-use-secrets-while-expanding-csi-volumes-on-node-alpha/), Longhorn cannot handle **online** expansion for encrypted volumes automatically unless you enable the feature gate `CSINodeExpandSecret`.
+Longhorn support for online expansion depends on Kubernetes.
+- Kubernetes natively supports [authenticated CSI storage resizing](https://kubernetes.io/blog/2023/12/15/csi-node-expand-secret-support-ga/) starting in v1.29.
+- In [Kubernetes v1.25 to v1.28](https://kubernetes.io/blog/2022/09/21/kubernetes-1-25-use-secrets-while-expanding-csi-volumes-on-node-alpha/), the feature gate `CSINodeExpandSecret` is required.
+  You can enable online expansion for encrypted volumes by specifying the following [encryption parameters in the StorageClass](../../../advanced-resources/security/volume-encryption#setting-up-kubernetes-secrets-and-storageclasses):
+
+- `csi.storage.k8s.io/node-expand-secret-name`
+- `csi.storage.k8s.io/node-expand-secret-namespace`
 
 If you cannot enable it but still prefer to do online expansion, you can:
 1. Login the node host the encrypted volume is attached to.
@@ -134,7 +140,7 @@ Longhorn currently does not support fully automatic expansion of the filesystem 
     kubectl -n longhorn-system exec -it <the share manager pod> -- resize2fs /dev/longhorn/<volume name>
     ```
 
-> **Important**:  
+> **Important**:
 > Online expansion is possible only for `ext4` volumes. Attempts to manually expand `xfs` volumes with `xfs_growfs` may initially appear to be successful, but issues occur when the workload is scaled up and the volume is reattached. In particular, the pods become stuck in the `ContainerCreating` state, and the logs show an error message about attempts to mount the filesystem.
 
 ##### Offline

--- a/content/docs/1.7.3/advanced-resources/security/volume-encryption.md
+++ b/content/docs/1.7.3/advanced-resources/security/volume-encryption.md
@@ -63,6 +63,8 @@ For more information, see [cryptsetup(8)](https://man7.org/linux/man-pages/man8/
     csi.storage.k8s.io/node-publish-secret-namespace: "longhorn-system"
     csi.storage.k8s.io/node-stage-secret-name: "longhorn-crypto"
     csi.storage.k8s.io/node-stage-secret-namespace: "longhorn-system"
+    csi.storage.k8s.io/node-expand-secret-name: "longhorn-crypto"
+    csi.storage.k8s.io/node-expand-secret-namespace: "longhorn-system"
   ```
 
 - Example of a StorageClass with a volume-specific Secret:
@@ -85,6 +87,8 @@ For more information, see [cryptsetup(8)](https://man7.org/linux/man-pages/man8/
     csi.storage.k8s.io/node-publish-secret-namespace: ${pvc.namespace}
     csi.storage.k8s.io/node-stage-secret-name: ${pvc.name}
     csi.storage.k8s.io/node-stage-secret-namespace: ${pvc.namespace}
+    csi.storage.k8s.io/node-expand-secret-name: ${pvc.name}
+    csi.storage.k8s.io/node-expand-secret-namespace: ${pvc.namespace}
   ```
 
 # Using an Encrypted Volume
@@ -96,7 +100,12 @@ A newly-created PVC remains in the `Pending` state until the associated Secret i
 
 # Filesystem Expansion
 
-Longhorn supports [offline expansion](../../../nodes-and-volumes/volumes/expansion/#encrypted-volume) for encrypted volumes.
+Longhorn supports [both online and offline expansion](../../../nodes-and-volumes/volumes/expansion/#encrypted-volume) for encrypted volumes.
+
+StorageClass parameters are needed to enable online expansion:
+
+- `csi.storage.k8s.io/node-expand-secret-name`
+- `csi.storage.k8s.io/node-expand-secret-namespace`
 
 # History
 - Encryption of volumes in `Filesystem` mode available starting v1.2.0 ([#1859](https://github.com/longhorn/longhorn/issues/1859))

--- a/content/docs/1.7.3/nodes-and-volumes/volumes/expansion.md
+++ b/content/docs/1.7.3/nodes-and-volumes/volumes/expansion.md
@@ -116,7 +116,13 @@ If a volume is reverted to a snapshot with smaller size, the frontend of the vol
 
 #### Encrypted volume
 
-Due to [the upstream limitation](https://kubernetes.io/blog/2022/09/21/kubernetes-1-25-use-secrets-while-expanding-csi-volumes-on-node-alpha/), Longhorn cannot handle **online** expansion for encrypted volumes automatically unless you enable the feature gate `CSINodeExpandSecret`.
+Longhorn support for online expansion depends on Kubernetes.
+- Kubernetes natively supports [authenticated CSI storage resizing](https://kubernetes.io/blog/2023/12/15/csi-node-expand-secret-support-ga/) starting in v1.29.
+- In [Kubernetes v1.25 to v1.28](https://kubernetes.io/blog/2022/09/21/kubernetes-1-25-use-secrets-while-expanding-csi-volumes-on-node-alpha/), the feature gate `CSINodeExpandSecret` is required.
+  You can enable online expansion for encrypted volumes by specifying the following [encryption parameters in the StorageClass](../../../advanced-resources/security/volume-encryption#setting-up-kubernetes-secrets-and-storageclasses):
+
+- `csi.storage.k8s.io/node-expand-secret-name`
+- `csi.storage.k8s.io/node-expand-secret-namespace`
 
 If you cannot enable it but still prefer to do online expansion, you can:
 1. Login the node host the encrypted volume is attached to.
@@ -134,7 +140,7 @@ Longhorn currently does not support fully automatic expansion of the filesystem 
     kubectl -n longhorn-system exec -it <the share manager pod> -- resize2fs /dev/longhorn/<volume name>
     ```
 
-> **Important**:  
+> **Important**:
 > Online expansion is possible only for `ext4` volumes. Attempts to manually expand `xfs` volumes with `xfs_growfs` may initially appear to be successful, but issues occur when the workload is scaled up and the volume is reattached. In particular, the pods become stuck in the `ContainerCreating` state, and the logs show an error message about attempts to mount the filesystem.
 
 ##### Offline

--- a/content/docs/1.8.0/advanced-resources/security/volume-encryption.md
+++ b/content/docs/1.8.0/advanced-resources/security/volume-encryption.md
@@ -63,6 +63,8 @@ For more information, see [cryptsetup(8)](https://man7.org/linux/man-pages/man8/
     csi.storage.k8s.io/node-publish-secret-namespace: "longhorn-system"
     csi.storage.k8s.io/node-stage-secret-name: "longhorn-crypto"
     csi.storage.k8s.io/node-stage-secret-namespace: "longhorn-system"
+    csi.storage.k8s.io/node-expand-secret-name: "longhorn-crypto"
+    csi.storage.k8s.io/node-expand-secret-namespace: "longhorn-system"
   ```
 
 - Example of a StorageClass with a volume-specific Secret:
@@ -85,6 +87,8 @@ For more information, see [cryptsetup(8)](https://man7.org/linux/man-pages/man8/
     csi.storage.k8s.io/node-publish-secret-namespace: ${pvc.namespace}
     csi.storage.k8s.io/node-stage-secret-name: ${pvc.name}
     csi.storage.k8s.io/node-stage-secret-namespace: ${pvc.namespace}
+    csi.storage.k8s.io/node-expand-secret-name: ${pvc.name}
+    csi.storage.k8s.io/node-expand-secret-namespace: ${pvc.namespace}
   ```
 
 # Using an Encrypted Volume
@@ -96,7 +100,12 @@ A newly-created PVC remains in the `Pending` state until the associated Secret i
 
 # Filesystem Expansion
 
-Longhorn supports [offline expansion](../../../nodes-and-volumes/volumes/expansion/#encrypted-volume) for encrypted volumes.
+Longhorn supports [both online and offline expansion](../../../nodes-and-volumes/volumes/expansion/#encrypted-volume) for encrypted volumes.
+
+StorageClass parameters are needed to enable online expansion:
+
+- `csi.storage.k8s.io/node-expand-secret-name`
+- `csi.storage.k8s.io/node-expand-secret-namespace`
 
 # History
 - Encryption of volumes in `Filesystem` mode available starting v1.2.0 ([#1859](https://github.com/longhorn/longhorn/issues/1859))


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#9902

#### What this PR does / why we need it:

Longhorn supports online encrypted volume expansion IF Kubernetes supports.

#### Special notes for your reviewer:

Online encrypted volume expansion may need to be enabled by cluster admin:

- Kubernetes v1.29+: this feature is enabled by default
- Kubernetes v1.25 to v1.28: feature gate is required

In a Kubernetes cluster which supports online encrypted volume expansion, this can be enabled by attaching required parameters in `StorageClass`.

#### Additional documentation or context
