### PR TITLE
docs(1.9.0): remove environment_check.sh

### DIFF
--- a/content/docs/1.9.0/deploy/install/_index.md
+++ b/content/docs/1.9.0/deploy/install/_index.md
@@ -40,7 +40,7 @@ Each node in the Kubernetes cluster where Longhorn is installed must fulfill the
 
 The Longhorn workloads must be able to run as root in order for Longhorn to be deployed and operated properly.
 
-[This script](#using-the-environment-check-script) can be used to check the Longhorn environment for potential issues.
+[Longhorn Command Line Tool](../../advanced-resources/longhornctl/) can be used to check the Longhorn environment for potential issues.
 
 For the minimum recommended hardware, refer to the [best practices guide.](../../best-practices/#minimum-recommended-hardware)
 
@@ -105,36 +105,22 @@ Use the `install` sub-command to install and set up the preflight dependencies b
 >
 > The documentation of the Linux distribution you are using should outline such requirements. For example, the [SLE Micro documentation](https://documentation.suse.com/sle-micro/6.0/html/Micro-transactional-updates/index.html#reference-transactional-update-usage) explains how all changes made by the `transactional-update` command become active only after the node is rebooted.
 
-### Using the Environment Check Script
-
-> **Deprecation Notice**
-> Since Longhorn v1.7.0, we have introduced the [Longhorn Command Line Tool](../../advanced-resources/longhornctl/). The functionality of the environment check script, [environment_check.sh](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) overlaps with that of the Longhorn Command Line Tool. Therefore, the script has been deprecated in v1.7.0 and is scheduled for removal in v1.8.0.
-
-We've written a script to help you gather enough information about the factors.
-
-Note `jq` maybe required to be installed locally prior to running env check script.
-
-To run script:
+### Using Longhorn Command Line Tool
 
 ```shell
-curl -sSfL https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/scripts/environment_check.sh | bash
+longhornctl --kube-config ~/.kube/config --image longhornio/longhorn-cli:v{{< current-version >}} install preflight
 ```
 
 Example of result:
 
 ```shell
-[INFO]  Required dependencies 'kubectl jq mktemp sort printf' are installed.
-[INFO]  All nodes have unique hostnames.
-[INFO]  Waiting for longhorn-environment-check pods to become ready (0/3)...
-[INFO]  All longhorn-environment-check pods are ready (3/3).
-[INFO]  MountPropagation is enabled
-[INFO]  Checking kernel release...
-[INFO]  Checking iscsid...
-[INFO]  Checking multipathd...
-[INFO]  Checking packages...
-[INFO]  Checking nfs client...
-[INFO]  Cleaning up longhorn-environment-check pods...
-[INFO]  Cleanup completed.
+INFO[2025-03-11T08:17:57+08:00] Initializing preflight installer
+INFO[2025-03-11T08:17:57+08:00] Cleaning up preflight installer
+INFO[2025-03-11T08:17:57+08:00] Running preflight installer
+INFO[2025-03-11T08:17:57+08:00] Installing dependencies with package manager
+INFO[2025-03-11T08:18:28+08:00] Installed dependencies with package manager
+INFO[2025-03-11T08:18:28+08:00] Cleaning up preflight installer
+INFO[2025-03-11T08:18:28+08:00] Completed preflight installer. Use 'longhornctl check preflight' to check the result.
 ```
 
 ### Pod Security Policy

--- a/content/docs/1.9.0/deploy/install/install-with-argocd.md
+++ b/content/docs/1.9.0/deploy/install/install-with-argocd.md
@@ -15,7 +15,7 @@ weight: 13
     ```
     Allow some time for the deployment of Argo CD components in the `argocd` namespace.
 
-> Use [this script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) to check the Longhorn environment for potential issues.
+> Use [Longhorn Command Line Tool](../../../advanced-resources/longhornctl/) to check the Longhorn environment for potential issues.
 
 ## Installing Longhorn
 

--- a/content/docs/1.9.0/deploy/install/install-with-fleet.md
+++ b/content/docs/1.9.0/deploy/install/install-with-fleet.md
@@ -16,7 +16,7 @@ weight: 11
     ```
     Allow some time for the deployment of Fleet components in the `cattle-fleet-system` namespace.
 
-> Use [this script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) to check the Longhorn environment for potential issues.
+> Use [Longhorn Command Line Tool](../../../advanced-resources/longhornctl/) to check the Longhorn environment for potential issues.
 
 ## Installing Longhorn
 

--- a/content/docs/1.9.0/deploy/install/install-with-flux.md
+++ b/content/docs/1.9.0/deploy/install/install-with-flux.md
@@ -22,7 +22,7 @@ weight: 12
       --personal
     ```
 
-> Use [this script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) to check the Longhorn environment for potential issues.
+> Use [Longhorn Command Line Tool](../../../advanced-resources/longhornctl/) to check the Longhorn environment for potential issues.
 
 ## Installing Longhorn
 

--- a/content/docs/1.9.0/deploy/install/install-with-helm-controller.md
+++ b/content/docs/1.9.0/deploy/install/install-with-helm-controller.md
@@ -9,7 +9,7 @@ In this section, you will learn how to install Longhorn with the HelmChart contr
 
 - Kubernetes cluster: Ensure that each node fulfills the [installation requirements](../#installation-requirements).  Cluster should be running RKE2 or K3s.
 
-> [This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+> [Longhorn Command Line Tool](../../../advanced-resources/longhornctl/) can be used to check the Longhorn environment for potential issues.
 
 ### Installing Longhorn
 

--- a/content/docs/1.9.0/deploy/install/install-with-helm.md
+++ b/content/docs/1.9.0/deploy/install/install-with-helm.md
@@ -10,7 +10,7 @@ In this section, you will learn how to install Longhorn with Helm.
 - Kubernetes cluster: Ensure that each node fulfills the [installation requirements](../#installation-requirements).
 - Your workstation: Install [Helm](https://helm.sh/docs/) v3.0 or later.
 
-> [This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+> [Longhorn Command Line Tool](../../../advanced-resources/longhornctl/) can be used to check the Longhorn environment for potential issues.
 
 ### Installing Longhorn
 

--- a/content/docs/1.9.0/deploy/install/install-with-kubectl.md
+++ b/content/docs/1.9.0/deploy/install/install-with-kubectl.md
@@ -8,7 +8,7 @@ weight: 8
 
 Each node in the Kubernetes cluster where Longhorn will be installed must fulfill [these requirements.](../#installation-requirements)
 
-[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[Longhorn Command Line Tool](../../../advanced-resources/longhornctl/) can be used to check the Longhorn environment for potential issues.
 
 The initial settings for Longhorn can be customized by [editing the deployment configuration file.](../../../advanced-resources/deploy/customizing-default-settings/#using-the-longhorn-deployment-yaml-file)
 

--- a/content/docs/1.9.0/deploy/install/install-with-rancher.md
+++ b/content/docs/1.9.0/deploy/install/install-with-rancher.md
@@ -12,7 +12,7 @@ If there is a new version of Longhorn available, you will see an `Upgrade Availa
 
 Each node in the Kubernetes cluster where Longhorn is installed must fulfill [these requirements.](../#installation-requirements)
 
-[This script](https://github.com/longhorn/longhorn/blob/v{{< current-version >}}/scripts/environment_check.sh) can be used to check the Longhorn environment for potential issues.
+[Longhorn Command Line Tool](../../../advanced-resources/longhornctl/) can be used to check the Longhorn environment for potential issues.
 
 ## Installation
 

--- a/content/docs/1.9.0/important-notes/_index.md
+++ b/content/docs/1.9.0/important-notes/_index.md
@@ -6,8 +6,10 @@ weight: 1
 This page lists important notes for Longhorn v{{< current-version >}}.
 Please see [here](https://github.com/longhorn/longhorn/releases/tag/v{{< current-version >}}) for the full release note.
 
+- [Removal](#removal)
+  - [Remove Environment Check Script](#remove-environment-check-script)
 - [Deprecation](#deprecation)
-  - [Environment Check Script](#environment-check-script)
+  - [Deprecate `longhorn.io/v1beta1` API](#deprecate-longhorniov1beta1-api)
 - [General](#general)
   - [Kubernetes Version Requirement](#kubernetes-version-requirement)
   - [Upgrade Check Events](#upgrade-check-events)
@@ -37,11 +39,13 @@ Please see [here](https://github.com/longhorn/longhorn/releases/tag/v{{< current
   - [Newly Introduced Functionalities since Longhorn v1.9.0](#newly-introduced-functionalities-since-longhorn-v190)
     - [Networking](#networking)
 
+## Removal
+
+### Remove Environment Check Script
+
+The environment check script (`environment_check.sh`), which was deprecated in v1.7.0, has been removed from v1.9.0. Use the [Longhorn Command Line Tool](../advanced-resources/longhornctl/) to check the Longhorn environment for potential issues.
+
 ## Deprecation
-
-### Environment Check Script
-
-The functionality of the [environment check script](https://github.com/longhorn/longhorn/blob/master/scripts/environment_check.sh) (`environment_check.sh`) overlaps with that of the Longhorn CLI, which is available starting with v1.7.0. Because of this, the script is deprecated in v1.7.0 and is scheduled for removal in v1.9.0.
 
 ### Deprecate `longhorn.io/v1beta1` API
 

--- a/content/docs/1.9.0/nodes-and-volumes/volumes/rwx-volumes.md
+++ b/content/docs/1.9.0/nodes-and-volumes/volumes/rwx-volumes.md
@@ -28,8 +28,6 @@ It is necessary to meet the following requirements in order to use RWX volumes.
 2. The hostname of each node is unique in the Kubernetes cluster.
 
     There is a dedicated recovery backend service for NFS servers in Longhorn system. When a client connects to an NFS server, the client's information, including its hostname, will be stored in the recovery backend. When a share-manager Pod or NFS server is abnormally terminated, Longhorn will create a new one. Within the 90-seconds grace period, clients will reclaim locks using the client information stored in the recovery backend.
-    
-    > **Tip:** The [environment check script](https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/scripts/environment_check.sh) helps users to check all nodes have unique hostnames.
 
 # Creation and Usage of an RWX Volume
 

--- a/content/docs/1.9.0/v2-data-engine/quick-start.md
+++ b/content/docs/1.9.0/v2-data-engine/quick-start.md
@@ -13,7 +13,7 @@ aliases:
   - [Restart `kubelet`](#restart-kubelet)
   - [Check Environment](#check-environment)
     - [Using the Longhorn Command Line Tool](#using-the-longhorn-command-line-tool)
-    - [Using the Script](#using-the-script)
+    - [Use Longhorn Command Line Tool](#use-longhorn-command-line-tool)
 - [Installation](#installation)
   - [Install Longhorn System](#install-longhorn-system)
   - [Enable V2 Data Engine](#enable-v2-data-engine)
@@ -179,12 +179,14 @@ worker1:
   - Module uio_pci_generic is loaded
 ```
 
-#### Using the Script
+#### Use Longhorn Command Line Tool
 
 Make sure everything is correctly configured and installed by
 ```
-bash -c "$(curl -sfL https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/scripts/environment_check.sh)" -s -s
+longhornctl --kube-config ~/.kube/config --image longhornio/longhorn-cli:v{{< current-version >}} install preflight --enable-spdk
 ```
+
+See [Longhorn Command Line Tool](../../advanced-resources/longhornctl/) for more information.
 
 ## Installation
 


### PR DESCRIPTION


#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#9239

#### What this PR does / why we need it:

environment_check.sh is removed since Longhorn v1.9.0 and is replaced by longhornctl.


#### Special notes for your reviewer:

#### Additional documentation or context
