### PR TITLE
doc(kb): recurring job pod stuck in pending state

### DIFF
--- a/content/kb/troubleshooting-recurring-job-pod-stuck-pending-state.md
+++ b/content/kb/troubleshooting-recurring-job-pod-stuck-pending-state.md
@@ -1,0 +1,31 @@
+---
+title: "Troubleshooting: Recurring Job Pod stuck in pending state"
+authors:
+- "Chin-Ya Huang"
+draft: false
+date: 2025-03-20
+versions:
+- "all"
+categories:
+- "recurring job"
+---
+
+## Applicable versions
+
+All Longhorn versions.
+
+## Symptoms
+
+After node reboot, a recurring job pod remains stuck in the `Pending` state, preventing scheduled tasks from running.
+
+## Potential Cause
+
+This issue may occur when a node is not ready at the time of a CronJob execution. The Kubernetes scheduler may attempt to place the job on a node that is still initializing after a reboot, leaving the pod in a `Pending` state.
+
+## Workaround
+
+Manually delete the `Pending` pod. The `CronJob` associated with the recurring job will create a new pod at the next scheduled execution time.
+
+## Related Information
+
+* Longhorn issue: [#7956](https://github.com/longhorn/longhorn/issues/7956)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#7956

#### What this PR does / why we need it:

Add KB to resolve the recurring job pod that remains stuck in the `Pending` state after node reboot.

#### Special notes for your reviewer:

Longhorn doesn't manage the lifecycle of the cronjob pod; this is an upstream issue.

#### Additional documentation or context

`None`
