### PR TITLE
docs: Clarify NFS version requirements for Longhorn features

### DIFF
--- a/content/docs/1.6.0/deploy/install/_index.md
+++ b/content/docs/1.6.0/deploy/install/_index.md
@@ -213,6 +213,9 @@ In Longhorn system, backup feature requires NFSv4, v4.1 or v4.2, and ReadWriteMa
   cat /boot/config-`uname -r`| grep CONFIG_NFS_V4_2
   ```
 
+To ensure Longhorn features function correctly, verify both that your kernel supports the required NFS versions and that the correct version is actively in use. 
+- Backup/Restore functionality requires **NFSv4.2**, **NFSv4.1**, or **NFSv4.0**.
+- ReadWriteMany (RWX) volumes require **NFSv4.1**.
 
 The command used to install a NFSv4 client differs depending on the Linux distribution.
 

--- a/content/docs/1.6.1/deploy/install/_index.md
+++ b/content/docs/1.6.1/deploy/install/_index.md
@@ -213,6 +213,9 @@ In Longhorn system, backup feature requires NFSv4, v4.1 or v4.2, and ReadWriteMa
   cat /boot/config-`uname -r`| grep CONFIG_NFS_V4_2
   ```
 
+To ensure Longhorn features function correctly, verify both that your kernel supports the required NFS versions and that the correct version is actively in use. 
+- Backup/Restore functionality requires **NFSv4.2**, **NFSv4.1**, or **NFSv4.0**.
+- ReadWriteMany (RWX) volumes require **NFSv4.1**.
 
 The command used to install a NFSv4 client differs depending on the Linux distribution.
 

--- a/content/docs/1.6.2/deploy/install/_index.md
+++ b/content/docs/1.6.2/deploy/install/_index.md
@@ -213,6 +213,9 @@ In Longhorn system, backup feature requires NFSv4, v4.1 or v4.2, and ReadWriteMa
   cat /boot/config-`uname -r`| grep CONFIG_NFS_V4_2
   ```
 
+To ensure Longhorn features function correctly, verify both that your kernel supports the required NFS versions and that the correct version is actively in use. 
+- Backup/Restore functionality requires **NFSv4.2**, **NFSv4.1**, or **NFSv4.0**.
+- ReadWriteMany (RWX) volumes require **NFSv4.1**.
 
 The command used to install a NFSv4 client differs depending on the Linux distribution.
 

--- a/content/docs/1.6.3/deploy/install/_index.md
+++ b/content/docs/1.6.3/deploy/install/_index.md
@@ -213,6 +213,9 @@ In Longhorn system, backup feature requires NFSv4, v4.1 or v4.2, and ReadWriteMa
   cat /boot/config-`uname -r`| grep CONFIG_NFS_V4_2
   ```
 
+To ensure Longhorn features function correctly, verify both that your kernel supports the required NFS versions and that the correct version is actively in use. 
+- Backup/Restore functionality requires **NFSv4.2**, **NFSv4.1**, or **NFSv4.0**.
+- ReadWriteMany (RWX) volumes require **NFSv4.1**.
 
 The command used to install a NFSv4 client differs depending on the Linux distribution.
 

--- a/content/docs/1.6.4/deploy/install/_index.md
+++ b/content/docs/1.6.4/deploy/install/_index.md
@@ -213,6 +213,9 @@ In Longhorn system, backup feature requires NFSv4, v4.1 or v4.2, and ReadWriteMa
   cat /boot/config-`uname -r`| grep CONFIG_NFS_V4_2
   ```
 
+To ensure Longhorn features function correctly, verify both that your kernel supports the required NFS versions and that the correct version is actively in use. 
+- Backup/Restore functionality requires **NFSv4.2**, **NFSv4.1**, or **NFSv4.0**.
+- ReadWriteMany (RWX) volumes require **NFSv4.1**.
 
 The command used to install a NFSv4 client differs depending on the Linux distribution.
 

--- a/content/docs/1.6.5/deploy/install/_index.md
+++ b/content/docs/1.6.5/deploy/install/_index.md
@@ -213,6 +213,9 @@ In Longhorn system, backup feature requires NFSv4, v4.1 or v4.2, and ReadWriteMa
   cat /boot/config-`uname -r`| grep CONFIG_NFS_V4_2
   ```
 
+To ensure Longhorn features function correctly, verify both that your kernel supports the required NFS versions and that the correct version is actively in use. 
+- Backup/Restore functionality requires **NFSv4.2**, **NFSv4.1**, or **NFSv4.0**.
+- ReadWriteMany (RWX) volumes require **NFSv4.1**.
 
 The command used to install a NFSv4 client differs depending on the Linux distribution.
 

--- a/content/docs/1.7.0/deploy/install/_index.md
+++ b/content/docs/1.7.0/deploy/install/_index.md
@@ -271,6 +271,9 @@ In Longhorn system, backup feature requires NFSv4, v4.1 or v4.2, and ReadWriteMa
   cat /boot/config-`uname -r`| grep CONFIG_NFS_V4_2
   ```
 
+To ensure Longhorn features function correctly, verify both that your kernel supports the required NFS versions and that the correct version is actively in use. 
+- Backup/Restore functionality requires **NFSv4.2**, **NFSv4.1**, or **NFSv4.0**.
+- ReadWriteMany (RWX) volumes require **NFSv4.1**.
 
 The command used to install a NFSv4 client differs depending on the Linux distribution.
 

--- a/content/docs/1.7.1/deploy/install/_index.md
+++ b/content/docs/1.7.1/deploy/install/_index.md
@@ -271,6 +271,9 @@ In Longhorn system, backup feature requires NFSv4, v4.1 or v4.2, and ReadWriteMa
   cat /boot/config-`uname -r`| grep CONFIG_NFS_V4_2
   ```
 
+To ensure Longhorn features function correctly, verify both that your kernel supports the required NFS versions and that the correct version is actively in use. 
+- Backup/Restore functionality requires **NFSv4.2**, **NFSv4.1**, or **NFSv4.0**.
+- ReadWriteMany (RWX) volumes require **NFSv4.1**.
 
 The command used to install a NFSv4 client differs depending on the Linux distribution.
 

--- a/content/docs/1.7.2/deploy/install/_index.md
+++ b/content/docs/1.7.2/deploy/install/_index.md
@@ -272,6 +272,9 @@ In Longhorn system, backup feature requires NFSv4, v4.1 or v4.2, and ReadWriteMa
   cat /boot/config-`uname -r`| grep CONFIG_NFS_V4_2
   ```
 
+To ensure Longhorn features function correctly, verify both that your kernel supports the required NFS versions and that the correct version is actively in use. 
+- Backup/Restore functionality requires **NFSv4.2**, **NFSv4.1**, or **NFSv4.0**.
+- ReadWriteMany (RWX) volumes require **NFSv4.1**.
 
 The command used to install a NFSv4 client differs depending on the Linux distribution.
 

--- a/content/docs/1.7.3/deploy/install/_index.md
+++ b/content/docs/1.7.3/deploy/install/_index.md
@@ -273,6 +273,9 @@ In Longhorn system, backup feature requires NFSv4, v4.1 or v4.2, and ReadWriteMa
   cat /boot/config-`uname -r`| grep CONFIG_NFS_V4_2
   ```
 
+To ensure Longhorn features function correctly, verify both that your kernel supports the required NFS versions and that the correct version is actively in use. 
+- Backup/Restore functionality requires **NFSv4.2**, **NFSv4.1**, or **NFSv4.0**.
+- ReadWriteMany (RWX) volumes require **NFSv4.1**.
 
 The command used to install a NFSv4 client differs depending on the Linux distribution.
 

--- a/content/docs/1.7.4/deploy/install/_index.md
+++ b/content/docs/1.7.4/deploy/install/_index.md
@@ -273,6 +273,9 @@ In Longhorn system, backup feature requires NFSv4, v4.1 or v4.2, and ReadWriteMa
   cat /boot/config-`uname -r`| grep CONFIG_NFS_V4_2
   ```
 
+To ensure Longhorn features function correctly, verify both that your kernel supports the required NFS versions and that the correct version is actively in use. 
+- Backup/Restore functionality requires **NFSv4.2**, **NFSv4.1**, or **NFSv4.0**.
+- ReadWriteMany (RWX) volumes require **NFSv4.1**.
 
 The command used to install a NFSv4 client differs depending on the Linux distribution.
 

--- a/content/docs/1.8.0/deploy/install/_index.md
+++ b/content/docs/1.8.0/deploy/install/_index.md
@@ -273,6 +273,9 @@ In Longhorn system, backup feature requires NFSv4, v4.1 or v4.2, and ReadWriteMa
   cat /boot/config-`uname -r`| grep CONFIG_NFS_V4_2
   ```
 
+To ensure Longhorn features function correctly, verify both that your kernel supports the required NFS versions and that the correct version is actively in use. 
+- Backup/Restore functionality requires **NFSv4.2**, **NFSv4.1**, or **NFSv4.0**.
+- ReadWriteMany (RWX) volumes require **NFSv4.1**.
 
 The command used to install a NFSv4 client differs depending on the Linux distribution.
 

--- a/content/docs/1.8.1/deploy/install/_index.md
+++ b/content/docs/1.8.1/deploy/install/_index.md
@@ -273,6 +273,9 @@ In Longhorn system, backup feature requires NFSv4, v4.1 or v4.2, and ReadWriteMa
   cat /boot/config-`uname -r`| grep CONFIG_NFS_V4_2
   ```
 
+To ensure Longhorn features function correctly, verify both that your kernel supports the required NFS versions and that the correct version is actively in use. 
+- Backup/Restore functionality requires **NFSv4.2**, **NFSv4.1**, or **NFSv4.0**.
+- ReadWriteMany (RWX) volumes require **NFSv4.1**.
 
 The command used to install a NFSv4 client differs depending on the Linux distribution.
 

--- a/content/docs/1.8.2/deploy/install/_index.md
+++ b/content/docs/1.8.2/deploy/install/_index.md
@@ -273,6 +273,9 @@ In Longhorn system, backup feature requires NFSv4, v4.1 or v4.2, and ReadWriteMa
   cat /boot/config-`uname -r`| grep CONFIG_NFS_V4_2
   ```
 
+To ensure Longhorn features function correctly, verify both that your kernel supports the required NFS versions and that the correct version is actively in use. 
+- Backup/Restore functionality requires **NFSv4.2**, **NFSv4.1**, or **NFSv4.0**.
+- ReadWriteMany (RWX) volumes require **NFSv4.1**.
 
 The command used to install a NFSv4 client differs depending on the Linux distribution.
 

--- a/content/docs/1.9.0/deploy/install/_index.md
+++ b/content/docs/1.9.0/deploy/install/_index.md
@@ -259,6 +259,9 @@ In Longhorn system, backup feature requires NFSv4, v4.1 or v4.2, and ReadWriteMa
   cat /boot/config-`uname -r`| grep CONFIG_NFS_V4_2
   ```
 
+To ensure Longhorn features function correctly, verify both that your kernel supports the required NFS versions and that the correct version is actively in use. 
+- Backup/Restore functionality requires **NFSv4.2**, **NFSv4.1**, or **NFSv4.0**.
+- ReadWriteMany (RWX) volumes require **NFSv4.1**.
 
 The command used to install a NFSv4 client differs depending on the Linux distribution.
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue (https://jira.suse.com/browse/SURE-9609?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel)

#### What this PR does / why we need it:
It updates the documentation (for installation in 1.9.x, 1.8.x, 1.7.x and 1.6.x.) to clarify the NFS version checks for Longhorn functionalities. It adds a clarification regarding the required NFS versions (NFSv4, NFSv4.1, and NFSv4.2) for Backup/Restore and ReadWriteMany (RWX) volumes. 

#### Special notes for your reviewer:
The changes are primarily documentation updates, and there are no code modifications.

#### Additional documentation or context
No