### PR TITLE
doc: Add documentation for replica recovery on RKE2 and k3s

### DIFF
--- a/content/docs/1.9.0/advanced-resources/data-recovery/export-from-replica.md
+++ b/content/docs/1.9.0/advanced-resources/data-recovery/export-from-replica.md
@@ -113,7 +113,10 @@ If the whole Kubernetes cluster or Longhorn system goes offline, the following s
          path: <host-path-to-replica>
      restartPolicy: Never
    ```
-  Replace `<current-version>` with the Longhorn version you are using, `<volume-name>` with the name of the volume you want to recover, and `<host-path-to-replica>` with the path to the replica directory you found in step 1.
+   Replace the placeholders with the following:
+   - `<current-version>`: The version of Longhorn you are using.
+   - `<volume-name>`: The name of the volume you want to recover.
+   - `<host-path-to-replica>`: The path to the replica directory you found in Step 1.
 
 **Result:** Now you should have a block device created on `/dev/longhorn/<volume_name>` for this device, such as `/dev/longhorn/pvc-06b4a8a8-b51d-42c6-a8cc-d8c8d6bc65bc` for the example above. Now you can mount the block device to get the access to the data.
 

--- a/content/docs/1.9.0/advanced-resources/data-recovery/export-from-replica.md
+++ b/content/docs/1.9.0/advanced-resources/data-recovery/export-from-replica.md
@@ -83,7 +83,8 @@ If the whole Kubernetes cluster or Longhorn system goes offline, the following s
    apiVersion: v1
    kind: Pod
    metadata:
-     name: longhorn-launch
+     name: longhorn-recovery
+     namespace: longhorn-system
    spec:
      hostPID: true
      containers:

--- a/content/docs/1.9.0/advanced-resources/data-recovery/export-from-replica.md
+++ b/content/docs/1.9.0/advanced-resources/data-recovery/export-from-replica.md
@@ -75,7 +75,7 @@ If the whole Kubernetes cluster or Longhorn system goes offline, the following s
 
    Containerd (RKE2/k3s)
 
-   To export the content of the volume in RKE2/k3s, you will need to create a static pod manifest. This manifest will launch the Longhorn engine and expose the volume.
+   To export the content of the volume in RKE2/k3s, you need to create a static pod manifest. This manifest will launch the Longhorn engine and expose the volume.
 
    Create a file named `longhorn-recovery.yaml` under `/var/lib/rancher/rke2/agent/pod-manifests/` with the following content:
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10714

#### What this PR does / why we need it:

This PR updates the [Export from Replica](https://longhorn.io/docs/1.8.1/advanced-resources/data-recovery/export-from-replica/) documentation to include instructions for RKE2 with containerd.

The current documentation only covers Docker-based installs (RKE1), but RKE2 has become the new standard and uses containerd as its container runtime. Adding RKE2 steps ensures users on newer Rancher Kubernetes distributions can follow accurate recovery procedures.

#### Special notes for your reviewer:

N/A

#### Additional documentation or context

N/A
