### PR TITLE
doc: suggest create a system backup before upgrade

### DIFF
--- a/content/docs/1.6.0/deploy/important-notes/index.md
+++ b/content/docs/1.6.0/deploy/important-notes/index.md
@@ -160,6 +160,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 ## V2 Data Engine
 

--- a/content/docs/1.6.0/deploy/upgrade/_index.md
+++ b/content/docs/1.6.0/deploy/upgrade/_index.md
@@ -37,6 +37,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.6.1/deploy/important-notes/index.md
+++ b/content/docs/1.6.1/deploy/important-notes/index.md
@@ -209,6 +209,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 ## V2 Data Engine
 

--- a/content/docs/1.6.1/deploy/upgrade/_index.md
+++ b/content/docs/1.6.1/deploy/upgrade/_index.md
@@ -37,6 +37,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.6.2/deploy/important-notes/index.md
+++ b/content/docs/1.6.2/deploy/important-notes/index.md
@@ -209,6 +209,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 ## V2 Data Engine
 

--- a/content/docs/1.6.2/deploy/upgrade/_index.md
+++ b/content/docs/1.6.2/deploy/upgrade/_index.md
@@ -37,6 +37,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.6.3/deploy/important-notes/index.md
+++ b/content/docs/1.6.3/deploy/important-notes/index.md
@@ -224,6 +224,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 ## V2 Data Engine
 

--- a/content/docs/1.6.3/deploy/upgrade/_index.md
+++ b/content/docs/1.6.3/deploy/upgrade/_index.md
@@ -37,6 +37,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.6.4/deploy/important-notes/index.md
+++ b/content/docs/1.6.4/deploy/important-notes/index.md
@@ -239,6 +239,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 ## V2 Data Engine
 

--- a/content/docs/1.6.4/deploy/upgrade/_index.md
+++ b/content/docs/1.6.4/deploy/upgrade/_index.md
@@ -37,6 +37,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.6.5/deploy/important-notes/index.md
+++ b/content/docs/1.6.5/deploy/important-notes/index.md
@@ -239,6 +239,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 ## V2 Data Engine
 

--- a/content/docs/1.6.5/deploy/upgrade/_index.md
+++ b/content/docs/1.6.5/deploy/upgrade/_index.md
@@ -37,6 +37,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.7.0/deploy/upgrade/_index.md
+++ b/content/docs/1.7.0/deploy/upgrade/_index.md
@@ -37,6 +37,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.7.0/important-notes/_index.md
+++ b/content/docs/1.7.0/important-notes/_index.md
@@ -167,6 +167,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 ## Resilience
 

--- a/content/docs/1.7.1/deploy/upgrade/_index.md
+++ b/content/docs/1.7.1/deploy/upgrade/_index.md
@@ -37,6 +37,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.7.1/important-notes/_index.md
+++ b/content/docs/1.7.1/important-notes/_index.md
@@ -149,6 +149,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 ## Resilience
 

--- a/content/docs/1.7.2/deploy/upgrade/_index.md
+++ b/content/docs/1.7.2/deploy/upgrade/_index.md
@@ -37,6 +37,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.7.2/important-notes/_index.md
+++ b/content/docs/1.7.2/important-notes/_index.md
@@ -151,6 +151,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 ## Resilience
 

--- a/content/docs/1.7.3/deploy/upgrade/_index.md
+++ b/content/docs/1.7.3/deploy/upgrade/_index.md
@@ -37,6 +37,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.7.3/important-notes/_index.md
+++ b/content/docs/1.7.3/important-notes/_index.md
@@ -155,6 +155,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 ## Resilience
 

--- a/content/docs/1.7.4/deploy/upgrade/_index.md
+++ b/content/docs/1.7.4/deploy/upgrade/_index.md
@@ -37,6 +37,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.7.4/important-notes/_index.md
+++ b/content/docs/1.7.4/important-notes/_index.md
@@ -166,6 +166,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 ## Resilience
 

--- a/content/docs/1.8.0/deploy/upgrade/_index.md
+++ b/content/docs/1.8.0/deploy/upgrade/_index.md
@@ -37,6 +37,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.8.0/important-notes/_index.md
+++ b/content/docs/1.8.0/important-notes/_index.md
@@ -67,6 +67,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 ### Install/Upgrade with Helm Controller
 Longhorn also supports installation or upgrade via the HelmChart controller built into RKE2 and K3s.  It allows management in a CRD YAML chart of most of the options that would normally be passed to the `helm` command-line tool. For more details on how it works, see [Install with Helm Controller](../deploy/install/install-with-helm-controller).

--- a/content/docs/1.8.1/deploy/upgrade/_index.md
+++ b/content/docs/1.8.1/deploy/upgrade/_index.md
@@ -37,6 +37,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.8.1/important-notes/_index.md
+++ b/content/docs/1.8.1/important-notes/_index.md
@@ -54,6 +54,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 ### Install/Upgrade with Helm Controller
 Longhorn also supports installation or upgrade via the HelmChart controller built into RKE2 and K3s.  It allows management in a CRD YAML chart of most of the options that would normally be passed to the `helm` command-line tool. For more details on how it works, see [Install with Helm Controller](../deploy/install/install-with-helm-controller).

--- a/content/docs/1.8.2/deploy/upgrade/_index.md
+++ b/content/docs/1.8.2/deploy/upgrade/_index.md
@@ -37,6 +37,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.8.2/important-notes/_index.md
+++ b/content/docs/1.8.2/important-notes/_index.md
@@ -65,6 +65,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 ### Install/Upgrade with Helm Controller
 Longhorn also supports installation or upgrade via the HelmChart controller built into RKE2 and K3s.  It allows management in a CRD YAML chart of most of the options that would normally be passed to the `helm` command-line tool. For more details on how it works, see [Install with Helm Controller](../deploy/install/install-with-helm-controller).

--- a/content/docs/1.9.0/deploy/upgrade/_index.md
+++ b/content/docs/1.9.0/deploy/upgrade/_index.md
@@ -37,6 +37,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 # Upgrading Longhorn
 

--- a/content/docs/1.9.0/important-notes/_index.md
+++ b/content/docs/1.9.0/important-notes/_index.md
@@ -78,6 +78,7 @@ Automated checks are only performed on some upgrade paths, and the pre-upgrade c
 - Ensure that all V2 Data Engine volumes are detached and the replicas are stopped.  The V2 Data Engine currently does not support live upgrades.
 - Avoid upgrading when volumes are in the "Faulted" status.  If all the replicas are deemed unusable, they may be deleted and data may be permanently lost (if no usable backups exist).
 - Avoid upgrading if a failed BackingImage exists.  For more information, see [Backing Image](../advanced-resources/backing-image/backing-image).
+- It is recommended to create a [Longhorn system backup](../advanced-resources/system-backup-restore/backup-longhorn-system) before performing the upgrade. This ensures that all critical resources, such as volumes and backing images, are backed up and can be restored in case any issues arise.
 
 ### Install/Upgrade with Helm Controller
 Longhorn also supports installation or upgrade via the HelmChart controller built into RKE2 and K3s.  It allows management in a CRD YAML chart of most of the options that would normally be passed to the `helm` command-line tool. For more details on how it works, see [Install with Helm Controller](../deploy/install/install-with-helm-controller).


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/10633

- by creating a system backup, we can ensure all the critical resources such as volumes and backing images are backed up and can be restored if there is any issue.