### PR TITLE
Update export-from-replica.md

### DIFF
--- a/content/docs/1.9.0/advanced-resources/data-recovery/export-from-replica.md
+++ b/content/docs/1.9.0/advanced-resources/data-recovery/export-from-replica.md
@@ -87,6 +87,7 @@ If the whole Kubernetes cluster or Longhorn system goes offline, the following s
      namespace: longhorn-system
    spec:
      hostPID: true
+     hostNetwork: true
      containers:
      - name: engine
        image: longhornio/longhorn-engine:v<current-version>
@@ -97,10 +98,13 @@ If the whole Kubernetes cluster or Longhorn system goes offline, the following s
        volumeMounts:
        - name: dev
          mountPath: /host/dev
+         readOnly: true
        - name: proc
          mountPath: /host/proc
+         readOnly: true
        - name: data
          mountPath: /volume
+         readOnly: true
      volumes:
      - name: dev
        hostPath:
@@ -120,6 +124,6 @@ If the whole Kubernetes cluster or Longhorn system goes offline, the following s
 
 **Result:** Now you should have a block device created on `/dev/longhorn/<volume_name>` for this device, such as `/dev/longhorn/pvc-06b4a8a8-b51d-42c6-a8cc-d8c8d6bc65bc` for the example above. Now you can mount the block device to get the access to the data.
 
-> To avoid accidental change of the volume content, it's recommended to use `mount -o ro` to mount the directory as `readonly`.
+> To avoid accidental change of the volume content, it's recommended to use `mount -o ro` to mount the directory as `readonly`. Also, added readOnly: true option to manifest example to reflect read-only in mount of volume.
 
 After you are done accessing the volume content, use `docker stop` to stop the container. For RKE2, clean up the resources by removing the static pod manifest file `sudo rm /var/lib/rancher/rke2/agent/pod-manifests/longhorn-recovery.yaml`


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/10787 (wasn't able to open issue on longhorn/website for some reason - so closed it myself)
Issue # 

#### What this PR does / why we need it:
This PR is for editing the example of the RKE2/K3s example manifest to reflect rke2 default cni with required "hostNetwork: true" and keeping consistent with message and recommendation of mounting the volume with "readOnly: true" added to the manifest under volumeMounts section.

#### Special notes for your reviewer:
Wasn't able to open the issue on longhorn/website; not sure of why. closed issue inside of longhorn/longhorn since it wasn't related to proper repo, but referenced here since I did attempt an open of an issue.

#### Additional documentation or context
Please review and correct any additions here if they are inadvisable, if linting isn't proper, verbiage is poor, etc as this is my first PR with SUSE.