### PR TITLE
docs(1.8.x): update backup target creation notes

### DIFF
--- a/content/docs/1.8.0/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/1.8.0/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -381,7 +381,11 @@ To include multiple certificates, one can just concatenate the different certifi
       VIRTUAL_HOSTED_STYLE: dHJ1ZQ== # true
     ```
 
-2. Deploy/update the secret and set it in `Settings/General/BackupTargetSecret`.
+2. Deploy/update the secret.
+3. Create correspondence backup target in `Settings > Backup Target`.
+   1. Name: The target name you want.
+   2. URL: `s3://<bucket-name>@<region>/`.
+   3. Credential Secret: `s3-compatible-backup-target-secret` in this example.
 
 ### Set up NFS Backupstore
 

--- a/content/docs/1.8.1/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/1.8.1/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -381,7 +381,11 @@ To include multiple certificates, one can just concatenate the different certifi
       VIRTUAL_HOSTED_STYLE: dHJ1ZQ== # true
     ```
 
-2. Deploy/update the secret and set it in `Settings/General/BackupTargetSecret`.
+2. Deploy/update the secret.
+3. Create correspondence backup target in `Settings > Backup Target`.
+   1. Name: The target name you want.
+   2. URL: `s3://<bucket-name>@<region>/`.
+   3. Credential Secret: `s3-compatible-backup-target-secret` in this example.
 
 ### Set up NFS Backupstore
 

--- a/content/docs/1.8.2/snapshots-and-backups/backup-and-restore/set-backup-target.md
+++ b/content/docs/1.8.2/snapshots-and-backups/backup-and-restore/set-backup-target.md
@@ -381,7 +381,11 @@ To include multiple certificates, one can just concatenate the different certifi
       VIRTUAL_HOSTED_STYLE: dHJ1ZQ== # true
     ```
 
-2. Deploy/update the secret and set it in `Settings/General/BackupTargetSecret`.
+2. Deploy/update the secret.
+3. Create correspondence backup target in `Settings > Backup Target`.
+   1. Name: The target name you want.
+   2. URL: `s3://<bucket-name>@<region>/`.
+   3. Credential Secret: `s3-compatible-backup-target-secret` in this example.
 
 ### Set up NFS Backupstore
 


### PR DESCRIPTION
…tent

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

[#10858](https://github.com/longhorn/longhorn/issues/10858#issue-3043315520)

#### What this PR does / why we need it:

The `BackupTargetSecret` was removed in UI. There is no such field `Settings/General/BackupTargetSecret`.

Update the doc and add additional notes about create S3 compatible object storage section.

#### Special notes for your reviewer:

#### Additional documentation or context
