### PR TITLE
docs(1.9.0): important notes for v2 backing image incompatibility

### DIFF
--- a/content/docs/1.9.0/important-notes/_index.md
+++ b/content/docs/1.9.0/important-notes/_index.md
@@ -12,6 +12,8 @@ Please see [here](https://github.com/longhorn/longhorn/releases/tag/v{{< current
   - [Deprecated Fields in CRDs](#deprecated-fields-in-crds)
 - [Deprecation](#deprecation)
   - [`longhorn.io/v1beta1` API](#longhorniov1beta1-api)
+- [Breaking Change](#breaking-change)
+  - [V2 Backing Image](#v2-backing-image)
 - [General](#general)
   - [Kubernetes Version Requirement](#kubernetes-version-requirement)
   - [CRD Upgrade Validation](#crd-upgrade-validation)
@@ -58,6 +60,28 @@ The `v1beta1` version of the Longhorn API is deprecated in v1.9.0 and will be re
 
 Deprecated APIs are no longer served and may therefore cause unexpected or unwanted behavior. Avoid using longhorn.io/v1beta1 in new code and, if possible, rewrite existing code to exclude this version.
 
+## Breaking Change
+
+### V2 Backing Image
+
+Starting with Longhorn v1.9.0, V2 backing images are incompatible with earlier versions due to naming conflicts in the extended attributes (`xattrs`) used by SPDK backing image logical volumes. As a result, V2 backing images must be deleted and recreated during the upgrade process.
+
+Since backing images cannot be deleted while volumes using them still exist, you must first back up, delete, and later restore those volumes.
+
+#### Upgrade Instructions
+
+- Before upgrading to v1.9.0:
+  - Verify that backup targets are functioning properly.
+  - Create full backups of all volumes that use a V2 backing image.
+  - Detach and delete these volumes after the backups complete.
+  - In the **Backing Image** page, save the specifications of all V2 backing images, including the name and the image source.
+  - Delete all V2 backing images.
+- After upgrading:
+  - Recreate the V2 backing images using the same names and image sources.
+  - Restore the volumes from your backups.
+
+For more details, see [Issue #10805](https://github.com/longhorn/longhorn/issues/10805).
+
 ## General
 
 ### Kubernetes Version Requirement
@@ -99,7 +123,7 @@ For more information, see [#6534](https://github.com/longhorn/longhorn/issues/65
 
 ### Offline Replica Rebuilding
 
-Starting with v1.9.0, Longhorn supports offline replica rebuilding, allowing degraded volumes to automatically rebuild replicas while detached.​
+Starting with v1.9.0, Longhorn supports offline replica rebuilding, allowing degraded volumes to automatically rebuild replicas while detached.
 
 For more information, see [Offline replica rebuilding](../advanced-resources/rebuilding/offline-replica-rebuilding) and [#8443](https://github.com/longhorn/longhorn/issues/8443).
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#10805

#### What this PR does / why we need it:

V2 backing image cannot be live upgrade from v1.8.x.

#### Special notes for your reviewer:

#### Additional documentation or context
