### PR TITLE
Adding the calendar embedding to the home page

### DIFF
--- a/layouts/partials/home/project-info.html
+++ b/layouts/partials/home/project-info.html
@@ -1,5 +1,22 @@
+
+
 <section class="section">
   <div class="container has-text-centered box push-down">
+    <div class="columns is-vcentered is-variable is-20">
+      <div class="column">
+        <p class="title is-size-4 is-size-5-mobile">
+          Get in touch
+        </p>
+        <p class="text-left font-weight-light">We hold monthly community meetings that are open to everybody. Subscribe to
+  <a href="https://webcal.prod.itx.linuxfoundation.org/lfx/a092M00001JWrBuQAL"><b>our calendar feed</b></a> to not miss them,
+  or view all of the events below.</a></p>
+         <br>
+         <br> 
+
+       <iframe src="https://zoom-lfx.platform.linuxfoundation.org/meetings/longhorn?view=month?embed=true" style="width: 100%; height: 1000px; border: 1px solid #cccccc" loading="lazy" frameborder="0"></iframe>
+      </div>
+  </div>
+
     <div class="columns is-vcentered is-variable is-20">
       <div class="column">
         <p class="title is-size-4 is-size-5-mobile">


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#10890

#### What this PR does / why we need it:

Added the community meeting calendar embedding and the calendar feed ICS link to the website home page for more visibility. 

#### Special notes for your reviewer:

#### Additional documentation or context
