### PR TITLE
docs(1.9.0): Update examples using deprecated crd version v1beta1 to v1beta2 on 1.9.0

### DIFF
--- a/content/docs/1.9.0/snapshots-and-backups/scheduling-backups-and-snapshots.md
+++ b/content/docs/1.9.0/snapshots-and-backups/scheduling-backups-and-snapshots.md
@@ -47,7 +47,7 @@ Recurring snapshots and backups can be configured from the `Recurring Job` page 
 
 You can also configure the recurring job by directly interacting with the Longhorn RecurringJob custom resource.
 ```yaml
-apiVersion: longhorn.io/v1beta1
+apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
   name: snapshot-1


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:
The docs for v1.9.0, v1.9.1 and v1.10 examples on the following pages points to CRDs with apiVersion `longhorn.io/v1beta1`:

- [Recurring Snapshots and Backups](https://longhorn.io/docs/1.9.0/snapshots-and-backups/scheduling-backups-and-snapshots/)
- [CSI VolumeSnapshot Associated with Longhorn BackingImage](https://longhorn.io/docs/1.9.0/snapshots-and-backups/csi-snapshot-support/csi-volume-snapshot-associated-with-longhorn-backing-image/)

This PR changes the examples using deprecated crd apiVersion v1beta1 to v1beta2

#### Special notes for your reviewer:

#### Additional documentation or context

I have installed helm chart 1.9.0, and created a recurring job shown in the example

```yaml
apiVersion: longhorn.io/v1beta1
kind: RecurringJob
metadata:
  name: snapshot-1
  namespace: longhorn-system
spec:
  cron: "* * * * *"
  task: "snapshot"
  groups:
  - default
  - group1
  retain: 1
  concurrency: 2
  labels:
    label/1: a
    label/2: b
```

helm didn't allow me to install due to not being able to find the CRD


i run `kubectl get crd recurringjobs.longhorn.io -o yaml` and its `.status` shows this:

```yaml
status:
  acceptedNames:
    kind: RecurringJob
    listKind: RecurringJobList
    plural: recurringjobs
    shortNames:
      - lhrj
    singular: recurringjob
  conditions:
    - lastTransitionTime: "2025-05-26T20:24:37Z"
      message: no conflicts found
      reason: NoConflicts
      status: "True"
      type: NamesAccepted
    - lastTransitionTime: "2025-05-26T20:24:37Z"
      message: the initial names have been accepted
      reason: InitialNamesAccepted
      status: "True"
      type: Established
  storedVersions:
    - v1beta2
  ```