### PR TITLE
Adding community page in the website

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -156,6 +156,11 @@ name = "Knowledge Base"
 url = "/kb"
 weight = 1
 
+[[menu.main]]
+name = "Community"
+url = "/community"
+weight = 2
+
 [mediaTypes."text/netlify"]
 delimiter = ""
 

--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -1,0 +1,5 @@
+---
+title: The Longhorn Community
+---
+
+Welcome to the Longhorn Community!

--- a/layouts/community/list.html
+++ b/layouts/community/list.html
@@ -1,0 +1,9 @@
+{{ define "title" }}
+{{ .Title }}
+{{ end }}
+
+{{ define "main" }}
+{{ partial "navbar.html" . }}
+{{ partial "community/content.html" . }}
+{{ partial "footer.html" . }}
+{{ end }}

--- a/layouts/community/single.html
+++ b/layouts/community/single.html
@@ -1,0 +1,9 @@
+{{ define "title" }}
+{{ .Title }} | The Longhorn Community
+{{ end }}
+
+{{ define "main" }}
+{{ partial "navbar.html" . }}
+{{ partial "community/content.html" . }}
+{{ partial "footer.html" . }}
+{{ end }}

--- a/layouts/partials/community/content.html
+++ b/layouts/partials/community/content.html
@@ -1,0 +1,109 @@
+{{ $posts := where site.RegularPages "Section" "blog" }}
+<section class="section">
+  <div class="columns is-vcentered is-variable is-20">
+    <div class="column">
+      <h2 class="title is-size-5 is-size-6-mobile">Get in touch</h2>
+      <p class="text-left font-weight-light">We host monthly community meetings that are open to everybody. Subscribe to
+        <a href="https://webcal.prod.itx.linuxfoundation.org/lfx/a092M00001JWrBuQAL"><b>our calendar feed</b></a> to not
+        miss them, or view all of the events below.
+      </p>
+
+      <h2 class="title is-size-5 is-size-6-mobile mt-5">Community Channels</h2>
+      <p class="text-left font-weight-light">Connect with the Longhorn community through various platforms.</p>
+      <h3 class="title is-size-6 is-size-7-mobile mt-3 mb-2">Slack:</h3>
+      <ul>
+        <li>
+          Join the discussion on the CNCF Slack instance in the <a
+            href="https://cloud-native.slack.com/messages/longhorn" target="_blank">#longhorn channel</a>. This is a
+          great place to learn about Longhorn, ask questions, and share your experiences.
+        </li>
+        <li>
+          <h3 class="title is-size-6 is-size-7-mobile mt-3 mb-2">Mailing Lists:</h3>
+          <ul>
+            <li><a href="https://lists.cncf.io/g/cncf-longhorn-dev" target="_blank">Longhorn Developers</a>: For
+              discussions around Longhorn development.</li>
+            <li><a href="https://lists.cncf.io/g/cncf-longhorn-users" target="_blank">Longhorn Users</a>: For general
+              discussions, questions, and community support.</li>
+          </ul>
+        </li>
+        <li>
+          <h3 class="title is-size-6 is-size-7-mobile mt-3 mb-2">Social:</h3>
+          <ul>
+            <li><a href="https://x.com/longhorn_io" target="_blank">X (formerly Twitter)</a>: Follow us for updates.
+            </li>
+            <li><a href="https://www.linkedin.com/company/longhornio/" target="_blank">LinkedIn</a>: Connect with the
+              Longhorn community professionally.</li>
+            <li><a href="https://m.youtube.com/@LonghornCNCF" target="_blank">YouTube</a>:
+              Watch our community meetings, tutorials, and more!</li>
+            <li><a href="https://bsky.app/profile/longhornio.bsky.social" target="_blank">Bluesky</a>: Find us on
+              Bluesky.</li>
+          </ul>
+        </li>
+      </ul>
+
+      <h2 class="title is-size-5 is-size-6-mobile mt-5">GitHub: Issues, Discussions & Code</h2>
+      <p class="text-left font-weight-light">
+        Our GitHub repositories are at the heart of Longhorn's development. Whether you have found a bug, have an idea
+        for
+        a new feature, or want to dive into the code, GitHub is your primary hub.
+      </p>
+      <ul class="github-links">
+        <li class="my-2">
+          <i class="fas fa-bug"></i> <strong>Reporting Bugs & Requesting Features:</strong>
+          Found an issue or have an enhancement in mind? Please use our dedicated <a
+            href="https://github.com/longhorn/longhorn/issues/new/choose" target="_blank">issue tracker</a> to submit
+          detailed reports and proposals.
+        </li>
+        <li class="my-2">
+          <i class="fas fa-comments"></i> <strong>Discussions:</strong>
+          For broader questions, design ideas, or general topics that are not specific bug reports, explore the <a
+            href="https://github.com/longhorn/longhorn/discussions" target="_blank">GitHub Discussions</a>. This is a
+          great place for community-driven conversations.
+        </li>
+        <li class="my-2">
+          <i class="fas fa-code-branch"></i> <strong>Contributing Code:</strong>
+          We welcome contributions! For minor fixes (like typos), feel free to open a Pull Request. For larger features,
+          we recommend <a href="https://github.com/longhorn/longhorn/issues/new/choose" target="_blank">opening an issue
+            first</a> to discuss the design with our maintainers. You can also check
+          out our <a href="https://github.com/longhorn/longhorn/wiki/Getting-started-with-Longhorn-Development"
+            target="_blank">developer guide</a> to get started.
+        </li>
+        <li class="my-2">
+          <strong>Important:</strong> For technical support or general queries, please utilize our <a
+            href="https://cloud-native.slack.com/messages/longhorn" target="_blank">Slack channels</a> or <a
+            href="https://lists.cncf.io/g/cncf-longhorn-users" target="_blank">mailing lists</a>. These community forums
+          are designed to ensure everyone can benefit from
+          shared solutions.
+        </li>
+      </ul>
+
+      <h2 class="title is-size-5 is-size-6-mobile mt-5">Contributing</h2>
+      <p class="text-left font-weight-light">
+        We welcome community contributions to Longhorn! Contributing is not limited to writing code; we also appreciate
+        filing issues, providing feedback, and suggesting new features. Many of Longhorn's features are
+        community-driven.
+      </p>
+      <p class="text-left font-weight-light">
+        If you are making a small change (for example, a typo fix), feel free to submit a Pull Request directly. For
+        larger
+        changes or new features, it is best to <a href="https://github.com/longhorn/longhorn/issues/new/choose"
+          target="_blank">submit a new issue</a> first to discuss the design with maintainers before implementing.
+      </p>
+      <p class="text-left font-weight-light">
+        When you are ready to get involved in contributing code, this <a
+          href="https://github.com/longhorn/longhorn/wiki/Getting-started-with-Longhorn-Development"
+          target="_blank">developer guide</a> will help you get up to speed. Remember to sign off your commits!
+      </p>
+      <p class="text-left font-weight-light">
+        Feel free to join the discussion on Longhorn development in the <a
+          href="https://cloud-native.slack.com/messages/longhorn-dev" target="_blank">#longhorn-dev</a> Slack channel.
+      </p>
+
+      <div>
+        <h2 class="title is-size-5 is-size-6-mobile mt-5">Community Events Calendar</h2>
+        <iframe src="https://zoom-lfx.platform.linuxfoundation.org/meetings/longhorn?view=month?embed=true"
+          style="width: 100%; height: 1000px; border: 1px solid #cccccc" loading="lazy" frameborder="0"></iframe>
+      </div>
+    </div>
+  </div>
+</section>

--- a/layouts/partials/community/content.html
+++ b/layouts/partials/community/content.html
@@ -14,28 +14,28 @@
       <ul>
         <li>
           Join the discussion on the CNCF Slack instance in the <a
-            href="https://cloud-native.slack.com/messages/longhorn" target="_blank">#longhorn channel</a>. This is a
+            href="https://cloud-native.slack.com/messages/longhorn" target="_blank"><b>#longhorn channel</b></a>. This is a
           great place to learn about Longhorn, ask questions, and share your experiences.
         </li>
         <li>
           <h3 class="title is-size-6 is-size-7-mobile mt-3 mb-2">Mailing Lists:</h3>
           <ul>
-            <li><a href="https://lists.cncf.io/g/cncf-longhorn-dev" target="_blank">Longhorn Developers</a>: For
+            <li><a href="https://lists.cncf.io/g/cncf-longhorn-dev" target="_blank"><b>Longhorn Developers</b></a>: For
               discussions around Longhorn development.</li>
-            <li><a href="https://lists.cncf.io/g/cncf-longhorn-users" target="_blank">Longhorn Users</a>: For general
+            <li><a href="https://lists.cncf.io/g/cncf-longhorn-users" target="_blank"><b>Longhorn Users</b></a>: For general
               discussions, questions, and community support.</li>
           </ul>
         </li>
         <li>
           <h3 class="title is-size-6 is-size-7-mobile mt-3 mb-2">Social:</h3>
           <ul>
-            <li><a href="https://x.com/longhorn_io" target="_blank">X (formerly Twitter)</a>: Follow us for updates.
+            <li><a href="https://x.com/longhorn_io" target="_blank"><b>X (formerly Twitter)</b></a>: Follow us for updates.
             </li>
-            <li><a href="https://www.linkedin.com/company/longhornio/" target="_blank">LinkedIn</a>: Connect with the
+            <li><a href="https://www.linkedin.com/company/longhornio/" target="_blank"><b>LinkedIn</b></a>: Connect with the
               Longhorn community professionally.</li>
-            <li><a href="https://m.youtube.com/@LonghornCNCF" target="_blank">YouTube</a>:
+            <li><a href="https://m.youtube.com/@LonghornCNCF" target="_blank"><b>YouTube</b></a>:
               Watch our community meetings, tutorials, and more!</li>
-            <li><a href="https://bsky.app/profile/longhornio.bsky.social" target="_blank">Bluesky</a>: Find us on
+            <li><a href="https://bsky.app/profile/longhornio.bsky.social" target="_blank"><b>Bluesky</b></a>: Find us on
               Bluesky.</li>
           </ul>
         </li>
@@ -51,27 +51,27 @@
         <li class="my-2">
           <i class="fas fa-bug"></i> <strong>Reporting Bugs & Requesting Features:</strong>
           Found an issue or have an enhancement in mind? Please use our dedicated <a
-            href="https://github.com/longhorn/longhorn/issues/new/choose" target="_blank">issue tracker</a> to submit
+            href="https://github.com/longhorn/longhorn/issues/new/choose" target="_blank"><b>issue tracker</b></a> to submit
           detailed reports and proposals.
         </li>
         <li class="my-2">
           <i class="fas fa-comments"></i> <strong>Discussions:</strong>
           For broader questions, design ideas, or general topics that are not specific bug reports, explore the <a
-            href="https://github.com/longhorn/longhorn/discussions" target="_blank">GitHub Discussions</a>. This is a
+            href="https://github.com/longhorn/longhorn/discussions" target="_blank"><b>GitHub Discussions</b></a>. This is a
           great place for community-driven conversations.
         </li>
         <li class="my-2">
           <i class="fas fa-code-branch"></i> <strong>Contributing Code:</strong>
           We welcome contributions! For minor fixes (like typos), feel free to open a Pull Request. For larger features,
-          we recommend <a href="https://github.com/longhorn/longhorn/issues/new/choose" target="_blank">opening an issue
-            first</a> to discuss the design with our maintainers. You can also check
+          we recommend <a href="https://github.com/longhorn/longhorn/issues/new/choose" target="_blank"><b>opening an issue
+            first</b></a> to discuss the design with our maintainers. You can also check
           out our <a href="https://github.com/longhorn/longhorn/wiki/Getting-started-with-Longhorn-Development"
-            target="_blank">developer guide</a> to get started.
+            target="_blank"><b>developer guide</b></a> to get started.
         </li>
         <li class="my-2">
           <strong>Important:</strong> For technical support or general queries, please utilize our <a
-            href="https://cloud-native.slack.com/messages/longhorn" target="_blank">Slack channels</a> or <a
-            href="https://lists.cncf.io/g/cncf-longhorn-users" target="_blank">mailing lists</a>. These community forums
+            href="https://cloud-native.slack.com/messages/longhorn" target="_blank"><b>Slack channels</b></a> or <a
+            href="https://lists.cncf.io/g/cncf-longhorn-users" target="_blank"><b>mailing lists</b></a>. These community forums
           are designed to ensure everyone can benefit from
           shared solutions.
         </li>
@@ -87,16 +87,16 @@
         If you are making a small change (for example, a typo fix), feel free to submit a Pull Request directly. For
         larger
         changes or new features, it is best to <a href="https://github.com/longhorn/longhorn/issues/new/choose"
-          target="_blank">submit a new issue</a> first to discuss the design with maintainers before implementing.
+          target="_blank"><b>submit a new issue</b></a> first to discuss the design with maintainers before implementing.
       </p>
       <p class="text-left font-weight-light">
         When you are ready to get involved in contributing code, this <a
           href="https://github.com/longhorn/longhorn/wiki/Getting-started-with-Longhorn-Development"
-          target="_blank">developer guide</a> will help you get up to speed. Remember to sign off your commits!
+          target="_blank"><b>developer guide</b></a> will help you get up to speed. Remember to sign off your commits!
       </p>
       <p class="text-left font-weight-light">
         Feel free to join the discussion on Longhorn development in the <a
-          href="https://cloud-native.slack.com/messages/longhorn-dev" target="_blank">#longhorn-dev</a> Slack channel.
+          href="https://cloud-native.slack.com/messages/longhorn-dev" target="_blank"><b>#longhorn-dev</b></a> Slack channel.
       </p>
 
       <div>


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

[Issue](https://github.com/longhorn/longhorn/issues/10890)

#### What this PR does / why we need it:

This PR adds the Longhorn community page. I have added clear sections for community channels, social media links, and detailed guidance on interacting via GitHub. 

#### Special notes for your reviewer:

- I have structured the new content logically with clear headings for readability.
- All provided Slack, mailing list, and social media links (X, LinkedIn, Bluesky, YouTube) are integrated.
- The GitHub section now clearly outlines how to report issues, participate in discussions, and contribute code.

#### Additional documentation or context:

N/A
