### PR TITLE
doc: add kb for clearing failed backing image replica on evicted nodes

### DIFF
--- a/content/kb/troubleshooting-failed-replicas-with-backing-images-remain-on-evicted-nodes.md
+++ b/content/kb/troubleshooting-failed-replicas-with-backing-images-remain-on-evicted-nodes.md
@@ -1,0 +1,40 @@
+---
+title: "Troubleshooting: Failed Replicas with Backing Images Remain On Evicted Nodes"
+authors:
+- "Raphanus Lo"
+draft: false
+date: 2025-06-05
+versions:
+- "v1.9.0 and earlier versions"
+categories:
+- "longhorn manager"
+---
+
+## Applicable versions
+
+v1.9.0 and earlier.
+
+## Symptoms
+
+After evicting a node, some volume replicas created from a backing image may enter an error state. Despite this, the associated volumes remain healthy.
+
+## Root Cause
+
+The issue occurs due to the unconditional deletion of backing image copies. If a backing image copy still in use is removed, its associated replica is forcibly shut down and marked as broken. This prevents the replica from being cleaned up during node eviction process.
+
+## Workaround
+
+To resolve this issue and maintain cluster stability, perform the following steps:
+
+1. Wait for affected volumes to automatically schedule new replicas on other nodes and confirm the volumes return to a healthy state.
+2. In the Node page, find the evicted node’s replica list and manually delete the failed replicas.
+
+The processes tied to these replicas have already terminated. Data is safely synchronized to new replicas, and no orphaned backing images will remain.
+
+## Fixed Versions
+
+Longhorn v1.8.2+, v1.9.1+
+
+## Reference
+
+[GitHub Issue #11053](https://github.com/longhorn/longhorn/issues/11053)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#11053

#### What this PR does / why we need it:

Workaround to users to cleanup the failed backing image volume replicas

#### Special notes for your reviewer:

#### Additional documentation or context
