### PR TITLE
docs(1.9.1, 1.10.0): Update examples using deprecated CRD apiVersion

### DIFF
--- a/content/docs/1.10.0/snapshots-and-backups/scheduling-backups-and-snapshots.md
+++ b/content/docs/1.10.0/snapshots-and-backups/scheduling-backups-and-snapshots.md
@@ -47,7 +47,7 @@ Recurring snapshots and backups can be configured from the `Recurring Job` page 
 
 You can also configure the recurring job by directly interacting with the Longhorn RecurringJob custom resource.
 ```yaml
-apiVersion: longhorn.io/v1beta1
+apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
   name: snapshot-1

--- a/content/docs/1.9.1/snapshots-and-backups/scheduling-backups-and-snapshots.md
+++ b/content/docs/1.9.1/snapshots-and-backups/scheduling-backups-and-snapshots.md
@@ -47,7 +47,7 @@ Recurring snapshots and backups can be configured from the `Recurring Job` page 
 
 You can also configure the recurring job by directly interacting with the Longhorn RecurringJob custom resource.
 ```yaml
-apiVersion: longhorn.io/v1beta1
+apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
   name: snapshot-1


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/11019

#### What this PR does / why we need it:
This PR changes the examples using deprecated crd apiVersion v1beta1 to v1beta2

#### Special notes for your reviewer:
This PR is a continuation of previous [PR](https://github.com/longhorn/website/pull/1127) that made changes for the already released v1.9.0

#### Additional documentation or context

