### PR TITLE
Update install-with-flux.md (https://charts.longhorn.io url deprecated)

### DIFF
--- a/content/docs/1.9.0/deploy/install/install-with-flux.md
+++ b/content/docs/1.9.0/deploy/install/install-with-flux.md
@@ -31,7 +31,7 @@ weight: 12
     ```bash
     kubectl create ns longhorn-system
     flux create source helm longhorn-repo \
-      --url=https://charts.longhorn.io \
+      --url=https://charts.rancher.io \
       --namespace=longhorn-system \
       --export > helmrepo.yaml
     kubectl apply -f helmrepo.yaml


### PR DESCRIPTION
#### What this PR does / why we need it:
The url https://charts.longhorn.io is not working (404), it should be replaced with the rancher chart that contains longhorn among other services.

#### Special notes for your reviewer:

#### Additional documentation or context
