### PR TITLE
Added mention of non-default data path to talos docs

### DIFF
--- a/content/docs/1.10.0/advanced-resources/os-distro-specific/talos-linux-support.md
+++ b/content/docs/1.10.0/advanced-resources/os-distro-specific/talos-linux-support.md
@@ -133,6 +133,8 @@ You need provide additional data path mounts to be accessible to the Kubernetes 
 
 These mounts are necessary to provide access to the host directories, and attach volumes required by Longhorn components.
 
+The [default data path](../../references/settings/#default-data-path) for Longhorn is `/var/lib/longhorn`. In order to use the below configuration in Talos, we must first set our default data path to `/var/mnt/longhorn`. The method to do this will depend on your [deployment method](../deploy/customizing-default-settings).
+
 ```yaml
 machine:
   kubelet:


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Fixes Issue (https://github.com/longhorn/longhorn/issues/11485)

#### What this PR does / why we need it:

Previous Longhorn deployments on Talos did not require customization of Longhorn. The new recommended instructions, for version v1.10.x, require a non-default path. Documenting this explicitly.
