### PR TITLE
docs: Add information on replica failure tolerance

### DIFF
--- a/content/docs/1.10.0/concepts.md
+++ b/content/docs/1.10.0/concepts.md
@@ -55,7 +55,7 @@ The Longhorn Manager communicates with the Kubernetes API server to create a new
 
 When the Longhorn Manager is asked to create a volume, it creates a Longhorn Engine instance on the node the volume is attached to, and it creates a replica on each node where a replica will be placed. Replicas should be placed on separate hosts to ensure maximum availability.
 
-The multiple data paths of the replicas ensure high availability of the Longhorn volume.  Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally.
+The multiple data paths of the replicas ensure high availability of the Longhorn volume. Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally. For a given volume, if the replica count is `N`, the Longhorn volume can tolerate a maximum of `N−1` replica failures. This is because at least one healthy replica is required for the volume to remain operational.
 
 The Longhorn Engine always runs in the same node as the Pod that uses the Longhorn volume. It synchronously replicates the volume across the multiple replicas stored on multiple nodes.
 

--- a/content/docs/1.7.0/concepts.md
+++ b/content/docs/1.7.0/concepts.md
@@ -55,7 +55,7 @@ The Longhorn Manager communicates with the Kubernetes API server to create a new
 
 When the Longhorn Manager is asked to create a volume, it creates a Longhorn Engine instance on the node the volume is attached to, and it creates a replica on each node where a replica will be placed. Replicas should be placed on separate hosts to ensure maximum availability.
 
-The multiple data paths of the replicas ensure high availability of the Longhorn volume.  Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally.
+The multiple data paths of the replicas ensure high availability of the Longhorn volume. Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally. For a given volume, if the replica count is `N`, the Longhorn volume can tolerate a maximum of `N−1` replica failures. This is because at least one healthy replica is required for the volume to remain operational.
 
 The Longhorn Engine always runs in the same node as the Pod that uses the Longhorn volume. It synchronously replicates the volume across the multiple replicas stored on multiple nodes.
 

--- a/content/docs/1.7.1/concepts.md
+++ b/content/docs/1.7.1/concepts.md
@@ -55,7 +55,7 @@ The Longhorn Manager communicates with the Kubernetes API server to create a new
 
 When the Longhorn Manager is asked to create a volume, it creates a Longhorn Engine instance on the node the volume is attached to, and it creates a replica on each node where a replica will be placed. Replicas should be placed on separate hosts to ensure maximum availability.
 
-The multiple data paths of the replicas ensure high availability of the Longhorn volume.  Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally.
+The multiple data paths of the replicas ensure high availability of the Longhorn volume. Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally. For a given volume, if the replica count is `N`, the Longhorn volume can tolerate a maximum of `N−1` replica failures. This is because at least one healthy replica is required for the volume to remain operational.
 
 The Longhorn Engine always runs in the same node as the Pod that uses the Longhorn volume. It synchronously replicates the volume across the multiple replicas stored on multiple nodes.
 

--- a/content/docs/1.7.2/concepts.md
+++ b/content/docs/1.7.2/concepts.md
@@ -55,7 +55,7 @@ The Longhorn Manager communicates with the Kubernetes API server to create a new
 
 When the Longhorn Manager is asked to create a volume, it creates a Longhorn Engine instance on the node the volume is attached to, and it creates a replica on each node where a replica will be placed. Replicas should be placed on separate hosts to ensure maximum availability.
 
-The multiple data paths of the replicas ensure high availability of the Longhorn volume.  Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally.
+The multiple data paths of the replicas ensure high availability of the Longhorn volume. Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally. For a given volume, if the replica count is `N`, the Longhorn volume can tolerate a maximum of `N−1` replica failures. This is because at least one healthy replica is required for the volume to remain operational.
 
 The Longhorn Engine always runs in the same node as the Pod that uses the Longhorn volume. It synchronously replicates the volume across the multiple replicas stored on multiple nodes.
 

--- a/content/docs/1.7.3/concepts.md
+++ b/content/docs/1.7.3/concepts.md
@@ -55,7 +55,7 @@ The Longhorn Manager communicates with the Kubernetes API server to create a new
 
 When the Longhorn Manager is asked to create a volume, it creates a Longhorn Engine instance on the node the volume is attached to, and it creates a replica on each node where a replica will be placed. Replicas should be placed on separate hosts to ensure maximum availability.
 
-The multiple data paths of the replicas ensure high availability of the Longhorn volume.  Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally.
+The multiple data paths of the replicas ensure high availability of the Longhorn volume. Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally. For a given volume, if the replica count is `N`, the Longhorn volume can tolerate a maximum of `N−1` replica failures. This is because at least one healthy replica is required for the volume to remain operational.
 
 The Longhorn Engine always runs in the same node as the Pod that uses the Longhorn volume. It synchronously replicates the volume across the multiple replicas stored on multiple nodes.
 

--- a/content/docs/1.7.4/concepts.md
+++ b/content/docs/1.7.4/concepts.md
@@ -55,7 +55,7 @@ The Longhorn Manager communicates with the Kubernetes API server to create a new
 
 When the Longhorn Manager is asked to create a volume, it creates a Longhorn Engine instance on the node the volume is attached to, and it creates a replica on each node where a replica will be placed. Replicas should be placed on separate hosts to ensure maximum availability.
 
-The multiple data paths of the replicas ensure high availability of the Longhorn volume.  Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally.
+The multiple data paths of the replicas ensure high availability of the Longhorn volume. Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally. For a given volume, if the replica count is `N`, the Longhorn volume can tolerate a maximum of `N−1` replica failures. This is because at least one healthy replica is required for the volume to remain operational.
 
 The Longhorn Engine always runs in the same node as the Pod that uses the Longhorn volume. It synchronously replicates the volume across the multiple replicas stored on multiple nodes.
 

--- a/content/docs/1.8.0/concepts.md
+++ b/content/docs/1.8.0/concepts.md
@@ -55,7 +55,7 @@ The Longhorn Manager communicates with the Kubernetes API server to create a new
 
 When the Longhorn Manager is asked to create a volume, it creates a Longhorn Engine instance on the node the volume is attached to, and it creates a replica on each node where a replica will be placed. Replicas should be placed on separate hosts to ensure maximum availability.
 
-The multiple data paths of the replicas ensure high availability of the Longhorn volume.  Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally.
+The multiple data paths of the replicas ensure high availability of the Longhorn volume. Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally. For a given volume, if the replica count is `N`, the Longhorn volume can tolerate a maximum of `N−1` replica failures. This is because at least one healthy replica is required for the volume to remain operational.
 
 The Longhorn Engine always runs in the same node as the Pod that uses the Longhorn volume. It synchronously replicates the volume across the multiple replicas stored on multiple nodes.
 

--- a/content/docs/1.8.1/concepts.md
+++ b/content/docs/1.8.1/concepts.md
@@ -55,7 +55,7 @@ The Longhorn Manager communicates with the Kubernetes API server to create a new
 
 When the Longhorn Manager is asked to create a volume, it creates a Longhorn Engine instance on the node the volume is attached to, and it creates a replica on each node where a replica will be placed. Replicas should be placed on separate hosts to ensure maximum availability.
 
-The multiple data paths of the replicas ensure high availability of the Longhorn volume.  Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally.
+The multiple data paths of the replicas ensure high availability of the Longhorn volume. Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally. For a given volume, if the replica count is `N`, the Longhorn volume can tolerate a maximum of `N−1` replica failures. This is because at least one healthy replica is required for the volume to remain operational.
 
 The Longhorn Engine always runs in the same node as the Pod that uses the Longhorn volume. It synchronously replicates the volume across the multiple replicas stored on multiple nodes.
 

--- a/content/docs/1.8.2/concepts.md
+++ b/content/docs/1.8.2/concepts.md
@@ -55,7 +55,7 @@ The Longhorn Manager communicates with the Kubernetes API server to create a new
 
 When the Longhorn Manager is asked to create a volume, it creates a Longhorn Engine instance on the node the volume is attached to, and it creates a replica on each node where a replica will be placed. Replicas should be placed on separate hosts to ensure maximum availability.
 
-The multiple data paths of the replicas ensure high availability of the Longhorn volume.  Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally.
+The multiple data paths of the replicas ensure high availability of the Longhorn volume. Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally. For a given volume, if the replica count is `N`, the Longhorn volume can tolerate a maximum of `N−1` replica failures. This is because at least one healthy replica is required for the volume to remain operational.
 
 The Longhorn Engine always runs in the same node as the Pod that uses the Longhorn volume. It synchronously replicates the volume across the multiple replicas stored on multiple nodes.
 

--- a/content/docs/1.8.3/concepts.md
+++ b/content/docs/1.8.3/concepts.md
@@ -55,7 +55,7 @@ The Longhorn Manager communicates with the Kubernetes API server to create a new
 
 When the Longhorn Manager is asked to create a volume, it creates a Longhorn Engine instance on the node the volume is attached to, and it creates a replica on each node where a replica will be placed. Replicas should be placed on separate hosts to ensure maximum availability.
 
-The multiple data paths of the replicas ensure high availability of the Longhorn volume.  Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally.
+The multiple data paths of the replicas ensure high availability of the Longhorn volume. Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally. For a given volume, if the replica count is `N`, the Longhorn volume can tolerate a maximum of `N−1` replica failures. This is because at least one healthy replica is required for the volume to remain operational.
 
 The Longhorn Engine always runs in the same node as the Pod that uses the Longhorn volume. It synchronously replicates the volume across the multiple replicas stored on multiple nodes.
 

--- a/content/docs/1.9.0/concepts.md
+++ b/content/docs/1.9.0/concepts.md
@@ -55,7 +55,7 @@ The Longhorn Manager communicates with the Kubernetes API server to create a new
 
 When the Longhorn Manager is asked to create a volume, it creates a Longhorn Engine instance on the node the volume is attached to, and it creates a replica on each node where a replica will be placed. Replicas should be placed on separate hosts to ensure maximum availability.
 
-The multiple data paths of the replicas ensure high availability of the Longhorn volume.  Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally.
+The multiple data paths of the replicas ensure high availability of the Longhorn volume. Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally. For a given volume, if the replica count is `N`, the Longhorn volume can tolerate a maximum of `N−1` replica failures. This is because at least one healthy replica is required for the volume to remain operational.
 
 The Longhorn Engine always runs in the same node as the Pod that uses the Longhorn volume. It synchronously replicates the volume across the multiple replicas stored on multiple nodes.
 

--- a/content/docs/1.9.1/concepts.md
+++ b/content/docs/1.9.1/concepts.md
@@ -55,7 +55,7 @@ The Longhorn Manager communicates with the Kubernetes API server to create a new
 
 When the Longhorn Manager is asked to create a volume, it creates a Longhorn Engine instance on the node the volume is attached to, and it creates a replica on each node where a replica will be placed. Replicas should be placed on separate hosts to ensure maximum availability.
 
-The multiple data paths of the replicas ensure high availability of the Longhorn volume.  Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally.
+The multiple data paths of the replicas ensure high availability of the Longhorn volume. Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally. For a given volume, if the replica count is `N`, the Longhorn volume can tolerate a maximum of `N−1` replica failures. This is because at least one healthy replica is required for the volume to remain operational.
 
 The Longhorn Engine always runs in the same node as the Pod that uses the Longhorn volume. It synchronously replicates the volume across the multiple replicas stored on multiple nodes.
 

--- a/content/docs/1.9.2/concepts.md
+++ b/content/docs/1.9.2/concepts.md
@@ -55,7 +55,7 @@ The Longhorn Manager communicates with the Kubernetes API server to create a new
 
 When the Longhorn Manager is asked to create a volume, it creates a Longhorn Engine instance on the node the volume is attached to, and it creates a replica on each node where a replica will be placed. Replicas should be placed on separate hosts to ensure maximum availability.
 
-The multiple data paths of the replicas ensure high availability of the Longhorn volume.  Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally.
+The multiple data paths of the replicas ensure high availability of the Longhorn volume. Even if a problem happens with a certain replica or with the Engine, the problem won't affect all the replicas or the Pod's access to the volume. The Pod will still function normally. For a given volume, if the replica count is `N`, the Longhorn volume can tolerate a maximum of `N−1` replica failures. This is because at least one healthy replica is required for the volume to remain operational.
 
 The Longhorn Engine always runs in the same node as the Pod that uses the Longhorn volume. It synchronously replicates the volume across the multiple replicas stored on multiple nodes.
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue [#11526](https://github.com/longhorn/longhorn/issues/11526)

#### What this PR does / why we need it:

It adds a clarification to the documentation regarding replica failure tolerance. This is needed to provide a more comprehensive explanation of how Longhorn ensures high availability and to answer a common customer question.

#### Special notes for your reviewer:

The change is located in the section discussing high availability and replicas. Please review the new sentence for clarity and accuracy.

#### Additional documentation or context:

N/A
