### PR TITLE
doc(1.10.0): v2 interrupt mode support

### DIFF
--- a/content/docs/1.10.0/important-notes/_index.md
+++ b/content/docs/1.10.0/important-notes/_index.md
@@ -22,6 +22,7 @@ Please see [here](https://github.com/longhorn/longhorn/releases/tag/v{{< current
   - [Longhorn System Upgrade](#longhorn-system-upgrade)
   - [Newly Introduced Functionalities since Longhorn v1.10.0](#newly-introduced-functionalities-since-longhorn-v1100)
     - [V2 Data Engine Without Hugepage Support](#v2-data-engine-without-hugepage-support)
+    - [V2 Data Engine Interrupt Mode Support](#v2-data-engine-interrupt-mode-support)
 
 ## Removal
 
@@ -107,3 +108,11 @@ Longhorn currently does not support live upgrading of V2 volumes. Ensure that al
 #### V2 Data Engine Without Hugepage Support
 
 Longhorn v1.10.0 allows running the V2 Data Engine without Hugepage by setting `data-engine-hugepage-enabled` to `{"v2":"false"}`. This reduces memory pressure on low‑spec nodes and increases deployment flexibility, though performance may be lower than with Hugepage.
+
+#### V2 Data Engine Interrupt Mode Support
+
+Adds interrupt mode to the V2 Data Engine to help reduce CPU usage. This feature is especially beneficial for clusters with idle or low I/O workloads, where conserving CPU resources is more important than minimizing latency.
+
+While interrupt mode lowers CPU consumption, it may introduce slightly higher I/O latency compared to polling mode. In addition, the current implementation uses a hybrid approach, which still incurs a minimal, constant CPU load even when interrupts are enabled.
+
+For more information, see [Interrupt Mode](../v2-data-engine/features/interrupt-mode) for more information.

--- a/content/docs/1.10.0/references/settings.md
+++ b/content/docs/1.10.0/references/settings.md
@@ -105,6 +105,7 @@ weight: 1
   - [Data Engine CPU Mask](#data-engine-cpu-mask)
   - [Data Engine Hugepage Enabled](#data-engine-hugepage-enabled)
   - [Data Engine Memory Size](#data-engine-memory-size)
+  - [Data Engine Interrupt Mode Enabled](#data-engine-interrupt-mode-enabled)
   - [Log Path](#log-path)
 
 ---
@@ -1146,6 +1147,20 @@ Applies only to the V2 Data Engine. Enables hugepages for the Storage Performanc
 > Default: `{"v2":"2048"}`
 
 Applies only to the V2 Data Engine. Specifies the memory size, in MiB, allocated to the Storage Performance Development Kit (SPDK) target daemon. When hugepage is enabled, this defines the hugepage size; when legacy memory is used, hugepage is disabled.
+
+#### Data Engine Interrupt Mode Enabled
+
+> Default: `{"v2":"false"}`
+
+Applies only to the **V2 Data Engine**.
+
+Controls whether the Storage Performance Development Kit (SPDK) target daemon runs in **interrupt mode** or the default **polling mode**.
+
+- `true`: Enables interrupt mode, reducing CPU usage by handling I/O through interrupts.
+- `false`: Keeps polling mode enabled for maximum performance and lowest latency.
+
+> **Warning**
+> - DO NOT CHANGE THIS SETTING WITH ATTACHED VOLUMES. Longhorn will block this setting update when there are attached v2 volumes.
 
 #### Log Path
 

--- a/content/docs/1.10.0/v2-data-engine/features/interrupt-mode.md
+++ b/content/docs/1.10.0/v2-data-engine/features/interrupt-mode.md
@@ -1,0 +1,72 @@
+---
+title: Interrupt Mode Support
+weight: 20
+aliases:
+- /spdk/features/interrupt-support.md
+---
+
+Starting with v1.10.0, Longhorn supports **SPDK interrupt mode** for V2 data engine volumes. Interrupt mode provides an alternative to the default **polling mode**, offering improved CPU efficiency in certain environment.
+
+Interrupt mode is particularly suitable for clusters with limited CPU resources and a relatively small number of volumes. While polling mode maximizes performance by keeping CPU utilization close to 100% on allocated cores, interrupt mode reduces CPU usage by allowing the SPDK reactor to adjust its usage dynamically instead of continuously polling.
+
+## Overview
+
+### Polling Mode vs Interrupt Mode
+
+**Polling Mode (Default)**:
+- Continuously polls for I/O operations
+- Provides the lowest latency
+- Consumes ~100% of the allocated CPU core at all times
+- Best suited for high-performance workloads with frequent I/O
+
+**Interrupt Mode**:
+- Uses interrupt-driven I/O handling
+- CPU consumption scales with the number of attached volumes
+- Better suited for resource-constrained environments
+
+## Prerequisites
+
+- Longhorn v1.10.0 or later
+- V2 data engine enabled
+- No attached v2 volumes when changing the setting
+
+## Configuration
+
+### Global Setting
+
+To enable interrupt mode globally, update the [data-engine-interrupt-mode-enabled](../../../references/settings#data-engine-interrupt-mode-enabled) setting.
+
+### Important Considerations
+
+- **Volume State Requirement**: The setting can only be changed when no V2 volumes are attached. Longhorn blocks updates if any V2 volume is active.
+- **Global Effect**: The setting applies to all V2 volumes.
+
+## Performance Characteristics
+
+### Recommended Use Cases
+
+Enable interrupt mode when:
+- Running in resource-constrained clusters
+- Managing only a small number of volumes
+- CPU resources are limited or shared with other workloads
+- I/O patterns are sporadic rather than continuous
+- Energy efficiency is a priority
+
+## Limitations
+
+### Hybrid Implementation
+
+The current V2 volume interrupt mode uses a hybrid approach for NVMe/TCP transport:
+
+- **Admin Queue Operations**: Still relies on periodic polling for keepalive and controller recovery
+- **I/O Queue Completion**: Uses polling for command completion
+- **Residual CPU Usage**: Results in a small but constant CPU load, even when attach volumes are idle
+
+### Performance Trade-offs
+
+- **Latency**: Slightly higher than polling mode
+
+### Operational Restrictions
+
+- **Setting Changes**: Cannot be modified while V2 volumes are attached
+- **Global Scope**: Applies globally; no per-volume override is available


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#9834

#### What this PR does / why we need it:

- Update setting reference
- Adds documentation for the new interrupt mode support in the V2 data engine.
- Adds important note

#### Special notes for your reviewer:

#### Additional documentation or context
