### PR TITLE
doc(backup): backup block size for volume creation

### DIFF
--- a/content/docs/1.10.0/snapshots-and-backups/backup-and-restore/configure-backup-block-size.md
+++ b/content/docs/1.10.0/snapshots-and-backups/backup-and-restore/configure-backup-block-size.md
@@ -35,7 +35,7 @@ To specify a custom backup block size during volume creation:
 
 1. Navigate to the **Volume** menu.
 2. Click **Create Volume**.
-3. In the volume creation dialog, select the desired **Backup Block Size**.
+3. In the volume creation dialog, inside `Advanced Configurations`, select the desired **Backup Block Size**.
 
 ## Specify The Backup Block Size In The Storage Class
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#5215

#### What this PR does / why we need it:

Inside the volume creation dialog, specify the backup block size in the `Advanced Configurations`.

#### Special notes for your reviewer:

#### Additional documentation or context

Ticket for UI change: longhorn/longhorn#11351