### PR TITLE
docs: update settings.longhorn.io for kubectl

### DIFF
--- a/content/docs/1.10.0/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/1.10.0/advanced-resources/deploy/customizing-default-settings.md
@@ -188,8 +188,8 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 
 ### Using Kubectl
 
-If you prefer to use the command line to update the setting, you could use `kubectl`.
-Due to the possibility of collisions with other CRDs, do not use the simple `settings`, but rather use `settings.longhorn.io` or `lhs` instead.
+If you prefer to update the setting from the command line, use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
 kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```

--- a/content/docs/1.10.0/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/1.10.0/advanced-resources/deploy/customizing-default-settings.md
@@ -189,8 +189,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+Due to the possibility of collisions with other CRDs, do not use the simple `settings`, but rather use `settings.longhorn.io` or `lhs` instead.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/1.10.0/v2-data-engine/features/replica-rebuild-qos.md
+++ b/content/docs/1.10.0/v2-data-engine/features/replica-rebuild-qos.md
@@ -12,7 +12,7 @@ Longhorn supports rebuild bandwidth throttling (QoS) for v2 volumes based on SPD
 * This setting can only be configured via kubectl:
 
 ```bash
-kubectl -n longhorn-system patch settings v2-data-engine-rebuilding-mbytes-per-second \
+kubectl -n longhorn-system patch settings.longhorn.io v2-data-engine-rebuilding-mbytes-per-second \
   --type=merge -p '{"value":"100"}'
 ```
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/11690

#### What this PR does / why we need it:
Due to the possibility of collisions with other CRDs, do not use the simple `settings`, but rather use `settings.longhorn.io` or `lhs` instead.

#### Special notes for your reviewer:
There are more updates to the docs for the older releases. What is the policy  for correcting old documentation ?
```
$ git grep "kubectl.* settings " | wc -l
48
```
The correct use of settings is common.
```
$ git grep "kubectl.* settings.longhorn.io " | wc -l
115
```
