### PR TITLE
Describe with proper accessMode

### DIFF
--- a/content/docs/1.10.0/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
+++ b/content/docs/1.10.0/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
@@ -13,7 +13,7 @@ Because the Longhorn CSI driver `csiDriver.spec.fsGroupPolicy` is set to `ReadWr
 * If non-empty, continue to the next step.
 * If empty, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `fsType` of the PV and `accessModes` of the PVC.
-* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnly`, continue to the next step.
+* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnce`, continue to the next step.
 * Otherwise, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `pod.spec.securityContext.fsGroupChangePolicy`.
 * If the `pod.spec.securityContext.fsGroupChangePolicy` is set to `always` or empty, the kubelet performs the following actions:

--- a/content/docs/1.10.1/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
+++ b/content/docs/1.10.1/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
@@ -13,7 +13,7 @@ Because the Longhorn CSI driver `csiDriver.spec.fsGroupPolicy` is set to `ReadWr
 * If non-empty, continue to the next step.
 * If empty, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `fsType` of the PV and `accessModes` of the PVC.
-* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnly`, continue to the next step.
+* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnce`, continue to the next step.
 * Otherwise, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `pod.spec.securityContext.fsGroupChangePolicy`.
 * If the `pod.spec.securityContext.fsGroupChangePolicy` is set to `always` or empty, the kubelet performs the following actions:

--- a/content/docs/1.11.0/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
+++ b/content/docs/1.11.0/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
@@ -13,7 +13,7 @@ Because the Longhorn CSI driver `csiDriver.spec.fsGroupPolicy` is set to `ReadWr
 * If non-empty, continue to the next step.
 * If empty, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `fsType` of the PV and `accessModes` of the PVC.
-* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnly`, continue to the next step.
+* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnce`, continue to the next step.
 * Otherwise, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `pod.spec.securityContext.fsGroupChangePolicy`.
 * If the `pod.spec.securityContext.fsGroupChangePolicy` is set to `always` or empty, the kubelet performs the following actions:

--- a/content/docs/1.8.0/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
+++ b/content/docs/1.8.0/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
@@ -13,7 +13,7 @@ Because the Longhorn CSI driver `csiDriver.spec.fsGroupPolicy` is set to `ReadWr
 * If non-empty, continue to the next step.
 * If empty, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `fsType` of the PV and `accessModes` of the PVC.
-* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnly`, continue to the next step.
+* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnce`, continue to the next step.
 * Otherwise, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `pod.spec.securityContext.fsGroupChangePolicy`.
 * If the `pod.spec.securityContext.fsGroupChangePolicy` is set to `always` or empty, the kubelet performs the following actions:

--- a/content/docs/1.8.1/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
+++ b/content/docs/1.8.1/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
@@ -13,7 +13,7 @@ Because the Longhorn CSI driver `csiDriver.spec.fsGroupPolicy` is set to `ReadWr
 * If non-empty, continue to the next step.
 * If empty, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `fsType` of the PV and `accessModes` of the PVC.
-* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnly`, continue to the next step.
+* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnce`, continue to the next step.
 * Otherwise, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `pod.spec.securityContext.fsGroupChangePolicy`.
 * If the `pod.spec.securityContext.fsGroupChangePolicy` is set to `always` or empty, the kubelet performs the following actions:

--- a/content/docs/1.8.2/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
+++ b/content/docs/1.8.2/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
@@ -13,7 +13,7 @@ Because the Longhorn CSI driver `csiDriver.spec.fsGroupPolicy` is set to `ReadWr
 * If non-empty, continue to the next step.
 * If empty, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `fsType` of the PV and `accessModes` of the PVC.
-* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnly`, continue to the next step.
+* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnce`, continue to the next step.
 * Otherwise, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `pod.spec.securityContext.fsGroupChangePolicy`.
 * If the `pod.spec.securityContext.fsGroupChangePolicy` is set to `always` or empty, the kubelet performs the following actions:

--- a/content/docs/1.8.3/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
+++ b/content/docs/1.8.3/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
@@ -13,7 +13,7 @@ Because the Longhorn CSI driver `csiDriver.spec.fsGroupPolicy` is set to `ReadWr
 * If non-empty, continue to the next step.
 * If empty, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `fsType` of the PV and `accessModes` of the PVC.
-* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnly`, continue to the next step.
+* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnce`, continue to the next step.
 * Otherwise, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `pod.spec.securityContext.fsGroupChangePolicy`.
 * If the `pod.spec.securityContext.fsGroupChangePolicy` is set to `always` or empty, the kubelet performs the following actions:

--- a/content/docs/1.9.0/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
+++ b/content/docs/1.9.0/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
@@ -13,7 +13,7 @@ Because the Longhorn CSI driver `csiDriver.spec.fsGroupPolicy` is set to `ReadWr
 * If non-empty, continue to the next step.
 * If empty, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `fsType` of the PV and `accessModes` of the PVC.
-* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnly`, continue to the next step.
+* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnce`, continue to the next step.
 * Otherwise, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `pod.spec.securityContext.fsGroupChangePolicy`.
 * If the `pod.spec.securityContext.fsGroupChangePolicy` is set to `always` or empty, the kubelet performs the following actions:

--- a/content/docs/1.9.1/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
+++ b/content/docs/1.9.1/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
@@ -13,7 +13,7 @@ Because the Longhorn CSI driver `csiDriver.spec.fsGroupPolicy` is set to `ReadWr
 * If non-empty, continue to the next step.
 * If empty, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `fsType` of the PV and `accessModes` of the PVC.
-* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnly`, continue to the next step.
+* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnce`, continue to the next step.
 * Otherwise, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `pod.spec.securityContext.fsGroupChangePolicy`.
 * If the `pod.spec.securityContext.fsGroupChangePolicy` is set to `always` or empty, the kubelet performs the following actions:

--- a/content/docs/1.9.2/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
+++ b/content/docs/1.9.2/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
@@ -13,7 +13,7 @@ Because the Longhorn CSI driver `csiDriver.spec.fsGroupPolicy` is set to `ReadWr
 * If non-empty, continue to the next step.
 * If empty, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `fsType` of the PV and `accessModes` of the PVC.
-* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnly`, continue to the next step.
+* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnce`, continue to the next step.
 * Otherwise, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `pod.spec.securityContext.fsGroupChangePolicy`.
 * If the `pod.spec.securityContext.fsGroupChangePolicy` is set to `always` or empty, the kubelet performs the following actions:

--- a/content/docs/1.9.3/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
+++ b/content/docs/1.9.3/nodes-and-volumes/volumes/pvc-ownership-and-permission.md
@@ -13,7 +13,7 @@ Because the Longhorn CSI driver `csiDriver.spec.fsGroupPolicy` is set to `ReadWr
 * If non-empty, continue to the next step.
 * If empty, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `fsType` of the PV and `accessModes` of the PVC.
-* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnly`, continue to the next step.
+* If the PV's `fsType` is defined and the PVC's `accessModes` list contains `ReadWriteOnce`, continue to the next step.
 * Otherwise, the Kubelet doesn't attempt to change the ownership and permission for the volume.
 1. Check `pod.spec.securityContext.fsGroupChangePolicy`.
 * If the `pod.spec.securityContext.fsGroupChangePolicy` is set to `always` or empty, the kubelet performs the following actions:


### PR DESCRIPTION
### Issue that it fixes

incorrect accessMode mentioned in pvc-ownership-and-permission doc.

#### What this PR does / why we need it:

So that the correct accessmode is used