### PR TITLE
docs: add IOMMU group isolation requirements

### DIFF
--- a/content/docs/1.11.0/advanced-resources/os-distro-specific/talos-linux-support.md
+++ b/content/docs/1.11.0/advanced-resources/os-distro-specific/talos-linux-support.md
@@ -146,20 +146,14 @@ talosctl upgrade --nodes 10.20.30.40 --image ghcr.io/siderolabs/installer:v1.7.6
 If we were unable to include the `--preserve` option in the upgrade command, perform the following steps:
 
 1. On the Longhorn UI, go to the **Nodes** page.
-
-1. Select the upgraded node, and then select **Edit node and disks** in the **Operation** menu.
-
-1. On the **Edit Node and Disks** page, set **Scheduling** to **Disable**, delete the disk, and then click **Save**.
-
-1. Select the upgraded node again, and then select **Edit node and disks** in the **Operation** menu.
-
-1. On the **Edit Node and Disks** page, add a disk and configure the following settings:
-
-   - **Path**: Specify `/var/lib/longhorn/`.
-   - **Storage Reserved**: Specify a value that matches your requirements. By default, it is set to 30% of the disk capacity.
-   - **Scheduling**: Select **Enable**.
-
-1. Click **Save**.
+2. Select the upgraded node, and then select **Edit node and disks** in the **Operation** menu.
+3. On the **Edit Node and Disks** page, set **Scheduling** to **Disable**, delete the disk, and then click **Save**.
+4. Select the upgraded node again, and then select **Edit node and disks** in the **Operation** menu.
+5. On the **Edit Node and Disks** page, add a disk and configure the following settings:
+    - **Path**: Specify `/var/lib/longhorn/`.
+    - **Storage Reserved**: Specify a value that matches your requirements. By default, it is set to 30% of the disk capacity.
+    - **Scheduling**: Select **Enable**.
+6. Click **Save**.
 
 Longhorn synchronizes the replicas based on the configured settings.
 

--- a/content/docs/1.11.0/troubleshoot/troubleshooting.md
+++ b/content/docs/1.11.0/troubleshoot/troubleshooting.md
@@ -6,10 +6,10 @@ weight: 1
   - [UI](#ui)
   - [Manager and Engines](#manager-and-engines)
   - [CSI driver](#csi-driver)
-  - [Flexvolume Driver](#flexvolume-driver)
-- [Common issues](#common-issues)
-  - [Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it](#volume-can-be-attacheddetached-from-ui-but-kubernetes-podstatefulset-etc-cannot-use-it)
-    - [Using with Flexvolume Plugin](#using-with-flexvolume-plugin)
+  - [FlexVolume Driver](#flexvolume-driver)
+- [Common Issues](#common-issues)
+  - [A volume can be attached/detached from the UI, but Kubernetes Pods/StatefulSets cannot use it](#a-volume-can-be-attacheddetached-from-the-ui-but-kubernetes-podsstatefulsets-cannot-use-it)
+    - [Using with FlexVolume Plugin](#using-with-flexvolume-plugin)
 
 ## Troubleshooting Guide
 
@@ -23,52 +23,54 @@ See [Support Bundle](../support-bundle) for detail.
 One exception is the `dmesg`, which needs to be retrieved from each node by the user.
 
 ### UI
+
 Make use of the Longhorn UI is a good start for the troubleshooting. For example, if Kubernetes cannot mount one volume correctly, after stop the workload, try to attach and mount that volume manually on one node and access the content to check if volume is intact.
 
 Also, the event logs in the UI dashboard provides some information of probably issues. Check for the event logs in `Warning` level.
 
 ### Manager and Engines
-You can get the logs from the Longhorn Manager and Engines to help with troubleshooting. The most useful logs are the ones from `longhorn-manager-xxx`, and the logs inside Longhorn instance managers, e.g. `instance-manager-xxxx`, `instance-manager-e-xxxx` and `instance-manager-r-xxxx`.
 
-Since normally there are multiple Longhorn Managers running at the same time, we recommend using [kubetail,](https://github.com/johanhaleby/kubetail) which is a great tool to keep track of the logs of multiple pods. To track the manager logs in real time, you can use:
+You can get the logs from the Longhorn Manager and Engines to help with troubleshooting. The most useful logs are the ones from `longhorn-manager-xxx`, and the logs inside Longhorn instance managers, for example, `instance-manager-xxxx`, `instance-manager-e-xxxx` and `instance-manager-r-xxxx`.
+
+Since normally there are multiple Longhorn Managers running at the same time, we recommend using [kubetail](https://github.com/johanhaleby/kubetail), which is a great tool to keep track of the logs of multiple pods. To track the manager logs in real time, you can use:
 
 ```
 kubetail longhorn-manager -n longhorn-system
 ```
 
-
 ### CSI driver
 
 For the CSI driver, check the logs for `csi-attacher-0` and `csi-provisioner-0`, as well as containers in `longhorn-csi-plugin-xxx`.
 
-### Flexvolume Driver
+### FlexVolume Driver
 
 The FlexVolume driver is deprecated as of Longhorn v0.8.0 and should no longer be used.
 
 First check where the driver has been installed on the node. Check the log of `longhorn-driver-deployer-xxxx` for that information.
 
-Then check the kubelet logs. The FlexVolume driver itself doesn't run inside the container. It would run along with the kubelet process.
+Then check the kubelet logs. The FlexVolume driver itself does not run inside the container. It would run along with the kubelet process.
 
 If kubelet is running natively on the node, you can use the following command to get the logs:
 ```
 journalctl -u kubelet
 ```
 
-Or if kubelet is running as a container (e.g. in RKE), use the following command instead:
+Or if kubelet is running as a container (for example, in RKE), use the following command instead:
 ```
 docker logs kubelet
 ```
 
-For even more detailed logs of Longhorn FlexVolume, run the following command on the node or inside the container (if kubelet is running as a container, e.g. in RKE):
+For even more detailed logs of Longhorn FlexVolume, run the following command on the node or inside the container (if kubelet is running as a container, for example, in RKE):
 ```
 touch /var/log/longhorn_driver.log
 ```
 
+## Common Issues
 
-## Common issues
-### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
+### A volume can be attached/detached from the UI, but Kubernetes Pods/StatefulSets cannot use it
 
-#### Using with Flexvolume Plugin
+#### Using with FlexVolume Plugin
+
 Check if the volume plugin directory has been set correctly. This is automatically detected unless the user explicitly sets it.
 
 By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
@@ -111,3 +113,9 @@ To enable profiling, you can:
 
     Profiler is disabled!
     ```
+
+### SPDK - Failed to bind NVMe disk (Error -22)
+
+If `instance-manager` logs show `failed to bind NVMe disk` or `vfio-pci: probe ... failed with error -22`, your NVMe likely shares an IOMMU group with a PCIe bridge.
+
+**Validation**: Run `lspci -t` or check `/sys/kernel/iommu_groups/`. If the NVMe and Bridge are in the same group, you must switch the disk to **AIO mode** in the Longhorn UI.

--- a/content/docs/1.11.0/v2-data-engine/prerequisites.md
+++ b/content/docs/1.11.0/v2-data-engine/prerequisites.md
@@ -44,7 +44,14 @@ When the V2 Data Engine is enabled, each instance-manager pod utilizes **1 CPU c
 
 SPDK leverages huge pages for enhancing performance and minimizing memory overhead. You must configure 2 MiB-sized huge pages on each Longhorn node to enable usage of huge pages. Specifically, 1024 pages (equivalent to a total of 2 GiB) must be available on each Longhorn node.
 
-
 ### Disk
 
 SPDK leverages kernel drivers to support every kind of disk that Linux supports. However, SPDK is equipped with a user space NVMe driver that provides zero-copy, highly parallel, direct access to an SSD from a user space application. Because of this, using **local NVMe disks** is highly recommended for enabling V2 volumes to achieve optimal storage performance.
+
+### IOMMU Group Isolation Requirement
+
+For the V2 Data Engine (SPDK) to claim a disk, the NVMe device must be isolatable. Because SPDK uses `vfio-pci`, the following hardware constraints apply:
+
+- **Group Ownership**: VFIO must claim the *entire* IOMMU group. If a group contains multiple devices (for example, an NVMe drive and a PCIe Bridge), all devices in that group must be bound to VFIO.
+- **Bridge Limitation**: The Linux kernel does not allow binding a PCIe Bridge or Switch Port to the `vfio-pci` driver.
+- **The Conflict**: If your hardware topology places an NVMe device in the same IOMMU group as its parent PCIe Bridge, SPDK cannot initialize the device. In these cases, the disk must be used in **AIO mode**.

--- a/content/docs/1.11.1/advanced-resources/os-distro-specific/talos-linux-support.md
+++ b/content/docs/1.11.1/advanced-resources/os-distro-specific/talos-linux-support.md
@@ -146,20 +146,14 @@ talosctl upgrade --nodes 10.20.30.40 --image ghcr.io/siderolabs/installer:v1.7.6
 If we were unable to include the `--preserve` option in the upgrade command, perform the following steps:
 
 1. On the Longhorn UI, go to the **Nodes** page.
-
-1. Select the upgraded node, and then select **Edit node and disks** in the **Operation** menu.
-
-1. On the **Edit Node and Disks** page, set **Scheduling** to **Disable**, delete the disk, and then click **Save**.
-
-1. Select the upgraded node again, and then select **Edit node and disks** in the **Operation** menu.
-
-1. On the **Edit Node and Disks** page, add a disk and configure the following settings:
-
-   - **Path**: Specify `/var/lib/longhorn/`.
-   - **Storage Reserved**: Specify a value that matches your requirements. By default, it is set to 30% of the disk capacity.
-   - **Scheduling**: Select **Enable**.
-
-1. Click **Save**.
+2. Select the upgraded node, and then select **Edit node and disks** in the **Operation** menu.
+3. On the **Edit Node and Disks** page, set **Scheduling** to **Disable**, delete the disk, and then click **Save**.
+4. Select the upgraded node again, and then select **Edit node and disks** in the **Operation** menu.
+5. On the **Edit Node and Disks** page, add a disk and configure the following settings:
+    - **Path**: Specify `/var/lib/longhorn/`.
+    - **Storage Reserved**: Specify a value that matches your requirements. By default, it is set to 30% of the disk capacity.
+    - **Scheduling**: Select **Enable**.
+6. Click **Save**.
 
 Longhorn synchronizes the replicas based on the configured settings.
 

--- a/content/docs/1.11.1/troubleshoot/troubleshooting.md
+++ b/content/docs/1.11.1/troubleshoot/troubleshooting.md
@@ -6,10 +6,10 @@ weight: 1
   - [UI](#ui)
   - [Manager and Engines](#manager-and-engines)
   - [CSI driver](#csi-driver)
-  - [Flexvolume Driver](#flexvolume-driver)
-- [Common issues](#common-issues)
-  - [Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it](#volume-can-be-attacheddetached-from-ui-but-kubernetes-podstatefulset-etc-cannot-use-it)
-    - [Using with Flexvolume Plugin](#using-with-flexvolume-plugin)
+  - [FlexVolume Driver](#flexvolume-driver)
+- [Common Issues](#common-issues)
+  - [A volume can be attached/detached from the UI, but Kubernetes Pods/StatefulSets cannot use it](#a-volume-can-be-attacheddetached-from-the-ui-but-kubernetes-podsstatefulsets-cannot-use-it)
+    - [Using with FlexVolume Plugin](#using-with-flexvolume-plugin)
 
 ## Troubleshooting Guide
 
@@ -23,52 +23,54 @@ See [Support Bundle](../support-bundle) for detail.
 One exception is the `dmesg`, which needs to be retrieved from each node by the user.
 
 ### UI
+
 Make use of the Longhorn UI is a good start for the troubleshooting. For example, if Kubernetes cannot mount one volume correctly, after stop the workload, try to attach and mount that volume manually on one node and access the content to check if volume is intact.
 
 Also, the event logs in the UI dashboard provides some information of probably issues. Check for the event logs in `Warning` level.
 
 ### Manager and Engines
-You can get the logs from the Longhorn Manager and Engines to help with troubleshooting. The most useful logs are the ones from `longhorn-manager-xxx`, and the logs inside Longhorn instance managers, e.g. `instance-manager-xxxx`, `instance-manager-e-xxxx` and `instance-manager-r-xxxx`.
 
-Since normally there are multiple Longhorn Managers running at the same time, we recommend using [kubetail,](https://github.com/johanhaleby/kubetail) which is a great tool to keep track of the logs of multiple pods. To track the manager logs in real time, you can use:
+You can get the logs from the Longhorn Manager and Engines to help with troubleshooting. The most useful logs are the ones from `longhorn-manager-xxx`, and the logs inside Longhorn instance managers, for example, `instance-manager-xxxx`, `instance-manager-e-xxxx` and `instance-manager-r-xxxx`.
+
+Since normally there are multiple Longhorn Managers running at the same time, we recommend using [kubetail](https://github.com/johanhaleby/kubetail), which is a great tool to keep track of the logs of multiple pods. To track the manager logs in real time, you can use:
 
 ```
 kubetail longhorn-manager -n longhorn-system
 ```
 
-
 ### CSI driver
 
 For the CSI driver, check the logs for `csi-attacher-0` and `csi-provisioner-0`, as well as containers in `longhorn-csi-plugin-xxx`.
 
-### Flexvolume Driver
+### FlexVolume Driver
 
 The FlexVolume driver is deprecated as of Longhorn v0.8.0 and should no longer be used.
 
 First check where the driver has been installed on the node. Check the log of `longhorn-driver-deployer-xxxx` for that information.
 
-Then check the kubelet logs. The FlexVolume driver itself doesn't run inside the container. It would run along with the kubelet process.
+Then check the kubelet logs. The FlexVolume driver itself does not run inside the container. It would run along with the kubelet process.
 
 If kubelet is running natively on the node, you can use the following command to get the logs:
 ```
 journalctl -u kubelet
 ```
 
-Or if kubelet is running as a container (e.g. in RKE), use the following command instead:
+Or if kubelet is running as a container (for example, in RKE), use the following command instead:
 ```
 docker logs kubelet
 ```
 
-For even more detailed logs of Longhorn FlexVolume, run the following command on the node or inside the container (if kubelet is running as a container, e.g. in RKE):
+For even more detailed logs of Longhorn FlexVolume, run the following command on the node or inside the container (if kubelet is running as a container, for example, in RKE):
 ```
 touch /var/log/longhorn_driver.log
 ```
 
+## Common Issues
 
-## Common issues
-### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
+### A volume can be attached/detached from the UI, but Kubernetes Pods/StatefulSets cannot use it
 
-#### Using with Flexvolume Plugin
+#### Using with FlexVolume Plugin
+
 Check if the volume plugin directory has been set correctly. This is automatically detected unless the user explicitly sets it.
 
 By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
@@ -111,3 +113,9 @@ To enable profiling, you can:
 
     Profiler is disabled!
     ```
+
+### SPDK - Failed to bind NVMe disk (Error -22)
+
+If `instance-manager` logs show `failed to bind NVMe disk` or `vfio-pci: probe ... failed with error -22`, your NVMe likely shares an IOMMU group with a PCIe bridge.
+
+**Validation**: Run `lspci -t` or check `/sys/kernel/iommu_groups/`. If the NVMe and Bridge are in the same group, you must switch the disk to **AIO mode** in the Longhorn UI.

--- a/content/docs/1.11.1/v2-data-engine/prerequisites.md
+++ b/content/docs/1.11.1/v2-data-engine/prerequisites.md
@@ -44,7 +44,14 @@ When the V2 Data Engine is enabled, each instance-manager pod utilizes **1 CPU c
 
 SPDK leverages huge pages for enhancing performance and minimizing memory overhead. You must configure 2 MiB-sized huge pages on each Longhorn node to enable usage of huge pages. Specifically, 1024 pages (equivalent to a total of 2 GiB) must be available on each Longhorn node.
 
-
 ### Disk
 
 SPDK leverages kernel drivers to support every kind of disk that Linux supports. However, SPDK is equipped with a user space NVMe driver that provides zero-copy, highly parallel, direct access to an SSD from a user space application. Because of this, using **local NVMe disks** is highly recommended for enabling V2 volumes to achieve optimal storage performance.
+
+### IOMMU Group Isolation Requirement
+
+For the V2 Data Engine (SPDK) to claim a disk, the NVMe device must be isolatable. Because SPDK uses `vfio-pci`, the following hardware constraints apply:
+
+- **Group Ownership**: VFIO must claim the *entire* IOMMU group. If a group contains multiple devices (for example, an NVMe drive and a PCIe Bridge), all devices in that group must be bound to VFIO.
+- **Bridge Limitation**: The Linux kernel does not allow binding a PCIe Bridge or Switch Port to the `vfio-pci` driver.
+- **The Conflict**: If your hardware topology places an NVMe device in the same IOMMU group as its parent PCIe Bridge, SPDK cannot initialize the device. In these cases, the disk must be used in **AIO mode**.

--- a/content/docs/1.11.2/advanced-resources/os-distro-specific/talos-linux-support.md
+++ b/content/docs/1.11.2/advanced-resources/os-distro-specific/talos-linux-support.md
@@ -146,20 +146,14 @@ talosctl upgrade --nodes 10.20.30.40 --image ghcr.io/siderolabs/installer:v1.7.6
 If we were unable to include the `--preserve` option in the upgrade command, perform the following steps:
 
 1. On the Longhorn UI, go to the **Nodes** page.
-
-1. Select the upgraded node, and then select **Edit node and disks** in the **Operation** menu.
-
-1. On the **Edit Node and Disks** page, set **Scheduling** to **Disable**, delete the disk, and then click **Save**.
-
-1. Select the upgraded node again, and then select **Edit node and disks** in the **Operation** menu.
-
-1. On the **Edit Node and Disks** page, add a disk and configure the following settings:
-
-   - **Path**: Specify `/var/lib/longhorn/`.
-   - **Storage Reserved**: Specify a value that matches your requirements. By default, it is set to 30% of the disk capacity.
-   - **Scheduling**: Select **Enable**.
-
-1. Click **Save**.
+2. Select the upgraded node, and then select **Edit node and disks** in the **Operation** menu.
+3. On the **Edit Node and Disks** page, set **Scheduling** to **Disable**, delete the disk, and then click **Save**.
+4. Select the upgraded node again, and then select **Edit node and disks** in the **Operation** menu.
+5. On the **Edit Node and Disks** page, add a disk and configure the following settings:
+    - **Path**: Specify `/var/lib/longhorn/`.
+    - **Storage Reserved**: Specify a value that matches your requirements. By default, it is set to 30% of the disk capacity.
+    - **Scheduling**: Select **Enable**.
+6. Click **Save**.
 
 Longhorn synchronizes the replicas based on the configured settings.
 

--- a/content/docs/1.11.2/troubleshoot/troubleshooting.md
+++ b/content/docs/1.11.2/troubleshoot/troubleshooting.md
@@ -6,10 +6,10 @@ weight: 1
   - [UI](#ui)
   - [Manager and Engines](#manager-and-engines)
   - [CSI driver](#csi-driver)
-  - [Flexvolume Driver](#flexvolume-driver)
-- [Common issues](#common-issues)
-  - [Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it](#volume-can-be-attacheddetached-from-ui-but-kubernetes-podstatefulset-etc-cannot-use-it)
-    - [Using with Flexvolume Plugin](#using-with-flexvolume-plugin)
+  - [FlexVolume Driver](#flexvolume-driver)
+- [Common Issues](#common-issues)
+  - [A volume can be attached/detached from the UI, but Kubernetes Pods/StatefulSets cannot use it](#a-volume-can-be-attacheddetached-from-the-ui-but-kubernetes-podsstatefulsets-cannot-use-it)
+    - [Using with FlexVolume Plugin](#using-with-flexvolume-plugin)
 
 ## Troubleshooting Guide
 
@@ -23,52 +23,54 @@ See [Support Bundle](../support-bundle) for detail.
 One exception is the `dmesg`, which needs to be retrieved from each node by the user.
 
 ### UI
+
 Make use of the Longhorn UI is a good start for the troubleshooting. For example, if Kubernetes cannot mount one volume correctly, after stop the workload, try to attach and mount that volume manually on one node and access the content to check if volume is intact.
 
 Also, the event logs in the UI dashboard provides some information of probably issues. Check for the event logs in `Warning` level.
 
 ### Manager and Engines
-You can get the logs from the Longhorn Manager and Engines to help with troubleshooting. The most useful logs are the ones from `longhorn-manager-xxx`, and the logs inside Longhorn instance managers, e.g. `instance-manager-xxxx`, `instance-manager-e-xxxx` and `instance-manager-r-xxxx`.
 
-Since normally there are multiple Longhorn Managers running at the same time, we recommend using [kubetail,](https://github.com/johanhaleby/kubetail) which is a great tool to keep track of the logs of multiple pods. To track the manager logs in real time, you can use:
+You can get the logs from the Longhorn Manager and Engines to help with troubleshooting. The most useful logs are the ones from `longhorn-manager-xxx`, and the logs inside Longhorn instance managers, for example, `instance-manager-xxxx`, `instance-manager-e-xxxx` and `instance-manager-r-xxxx`.
+
+Since normally there are multiple Longhorn Managers running at the same time, we recommend using [kubetail](https://github.com/johanhaleby/kubetail), which is a great tool to keep track of the logs of multiple pods. To track the manager logs in real time, you can use:
 
 ```
 kubetail longhorn-manager -n longhorn-system
 ```
 
-
 ### CSI driver
 
 For the CSI driver, check the logs for `csi-attacher-0` and `csi-provisioner-0`, as well as containers in `longhorn-csi-plugin-xxx`.
 
-### Flexvolume Driver
+### FlexVolume Driver
 
 The FlexVolume driver is deprecated as of Longhorn v0.8.0 and should no longer be used.
 
 First check where the driver has been installed on the node. Check the log of `longhorn-driver-deployer-xxxx` for that information.
 
-Then check the kubelet logs. The FlexVolume driver itself doesn't run inside the container. It would run along with the kubelet process.
+Then check the kubelet logs. The FlexVolume driver itself does not run inside the container. It would run along with the kubelet process.
 
 If kubelet is running natively on the node, you can use the following command to get the logs:
 ```
 journalctl -u kubelet
 ```
 
-Or if kubelet is running as a container (e.g. in RKE), use the following command instead:
+Or if kubelet is running as a container (for example, in RKE), use the following command instead:
 ```
 docker logs kubelet
 ```
 
-For even more detailed logs of Longhorn FlexVolume, run the following command on the node or inside the container (if kubelet is running as a container, e.g. in RKE):
+For even more detailed logs of Longhorn FlexVolume, run the following command on the node or inside the container (if kubelet is running as a container, for example, in RKE):
 ```
 touch /var/log/longhorn_driver.log
 ```
 
+## Common Issues
 
-## Common issues
-### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
+### A volume can be attached/detached from the UI, but Kubernetes Pods/StatefulSets cannot use it
 
-#### Using with Flexvolume Plugin
+#### Using with FlexVolume Plugin
+
 Check if the volume plugin directory has been set correctly. This is automatically detected unless the user explicitly sets it.
 
 By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
@@ -111,3 +113,9 @@ To enable profiling, you can:
 
     Profiler is disabled!
     ```
+
+### SPDK - Failed to bind NVMe disk (Error -22)
+
+If `instance-manager` logs show `failed to bind NVMe disk` or `vfio-pci: probe ... failed with error -22`, your NVMe likely shares an IOMMU group with a PCIe bridge.
+
+**Validation**: Run `lspci -t` or check `/sys/kernel/iommu_groups/`. If the NVMe and Bridge are in the same group, you must switch the disk to **AIO mode** in the Longhorn UI.

--- a/content/docs/1.11.2/v2-data-engine/prerequisites.md
+++ b/content/docs/1.11.2/v2-data-engine/prerequisites.md
@@ -44,7 +44,14 @@ When the V2 Data Engine is enabled, each instance-manager pod utilizes **1 CPU c
 
 SPDK leverages huge pages for enhancing performance and minimizing memory overhead. You must configure 2 MiB-sized huge pages on each Longhorn node to enable usage of huge pages. Specifically, 1024 pages (equivalent to a total of 2 GiB) must be available on each Longhorn node.
 
-
 ### Disk
 
 SPDK leverages kernel drivers to support every kind of disk that Linux supports. However, SPDK is equipped with a user space NVMe driver that provides zero-copy, highly parallel, direct access to an SSD from a user space application. Because of this, using **local NVMe disks** is highly recommended for enabling V2 volumes to achieve optimal storage performance.
+
+### IOMMU Group Isolation Requirement
+
+For the V2 Data Engine (SPDK) to claim a disk, the NVMe device must be isolatable. Because SPDK uses `vfio-pci`, the following hardware constraints apply:
+
+- **Group Ownership**: VFIO must claim the *entire* IOMMU group. If a group contains multiple devices (for example, an NVMe drive and a PCIe Bridge), all devices in that group must be bound to VFIO.
+- **Bridge Limitation**: The Linux kernel does not allow binding a PCIe Bridge or Switch Port to the `vfio-pci` driver.
+- **The Conflict**: If your hardware topology places an NVMe device in the same IOMMU group as its parent PCIe Bridge, SPDK cannot initialize the device. In these cases, the disk must be used in **AIO mode**.

--- a/content/docs/1.12.0/advanced-resources/os-distro-specific/talos-linux-support.md
+++ b/content/docs/1.12.0/advanced-resources/os-distro-specific/talos-linux-support.md
@@ -116,6 +116,9 @@ machine:
 #     - name: uio_pci_generic
 ```
 
+> **Note:** 
+> If SPDK initialization fails on Talos with `nsenter: operation not permitted`, it may be due to hardware IOMMU group sharing. Refer to the [V2 Data Engine Prerequisites](../../../v2-data-engine/prerequisites#prerequisites) to verify your hardware topology.
+
 > **Note:**
 > Talos Linux v1.7.x and earlier versions do not include the `uio_pci_generic` kernel module. If the system device supports `vfio_pci`, which is the preferred kernel module for SPDK application deployment, we are not required to install and enable the `uio_pci_generic` kernel driver. For more information, see [System Configuration User Guide](https://spdk.io/doc/system_configuration.html) in the SPDK documentation.
 >

--- a/content/docs/1.12.0/advanced-resources/os-distro-specific/talos-linux-support.md
+++ b/content/docs/1.12.0/advanced-resources/os-distro-specific/talos-linux-support.md
@@ -116,9 +116,6 @@ machine:
 #     - name: uio_pci_generic
 ```
 
-> **Note:** 
-> If SPDK initialization fails on Talos with `nsenter: operation not permitted`, it may be due to hardware IOMMU group sharing. Refer to the [V2 Data Engine Prerequisites](../../../v2-data-engine/prerequisites#prerequisites) to verify your hardware topology.
-
 > **Note:**
 > Talos Linux v1.7.x and earlier versions do not include the `uio_pci_generic` kernel module. If the system device supports `vfio_pci`, which is the preferred kernel module for SPDK application deployment, we are not required to install and enable the `uio_pci_generic` kernel driver. For more information, see [System Configuration User Guide](https://spdk.io/doc/system_configuration.html) in the SPDK documentation.
 >
@@ -149,20 +146,14 @@ talosctl upgrade --nodes 10.20.30.40 --image ghcr.io/siderolabs/installer:v1.7.6
 If we were unable to include the `--preserve` option in the upgrade command, perform the following steps:
 
 1. On the Longhorn UI, go to the **Nodes** page.
-
-1. Select the upgraded node, and then select **Edit node and disks** in the **Operation** menu.
-
-1. On the **Edit Node and Disks** page, set **Scheduling** to **Disable**, delete the disk, and then click **Save**.
-
-1. Select the upgraded node again, and then select **Edit node and disks** in the **Operation** menu.
-
-1. On the **Edit Node and Disks** page, add a disk and configure the following settings:
-
-   - **Path**: Specify `/var/lib/longhorn/`.
-   - **Storage Reserved**: Specify a value that matches your requirements. By default, it is set to 30% of the disk capacity.
-   - **Scheduling**: Select **Enable**.
-
-1. Click **Save**.
+2. Select the upgraded node, and then select **Edit node and disks** in the **Operation** menu.
+3. On the **Edit Node and Disks** page, set **Scheduling** to **Disable**, delete the disk, and then click **Save**.
+4. Select the upgraded node again, and then select **Edit node and disks** in the **Operation** menu.
+5. On the **Edit Node and Disks** page, add a disk and configure the following settings:
+    - **Path**: Specify `/var/lib/longhorn/`.
+    - **Storage Reserved**: Specify a value that matches your requirements. By default, it is set to 30% of the disk capacity.
+    - **Scheduling**: Select **Enable**.
+6. Click **Save**.
 
 Longhorn synchronizes the replicas based on the configured settings.
 

--- a/content/docs/1.12.0/troubleshoot/troubleshooting.md
+++ b/content/docs/1.12.0/troubleshoot/troubleshooting.md
@@ -6,10 +6,10 @@ weight: 1
   - [UI](#ui)
   - [Manager and Engines](#manager-and-engines)
   - [CSI driver](#csi-driver)
-  - [Flexvolume Driver](#flexvolume-driver)
+  - [FlexVolume Driver](#flexvolume-driver)
 - [Common Issues](#common-issues)
-  - [Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it](#volume-can-be-attacheddetached-from-ui-but-kubernetes-podstatefulset-etc-cannot-use-it)
-    - [Using with Flexvolume Plugin](#using-with-flexvolume-plugin)
+  - [A volume can be attached/detached from the UI, but Kubernetes Pods/StatefulSets cannot use it](#a-volume-can-be-attacheddetached-from-the-ui-but-kubernetes-podsstatefulsets-cannot-use-it)
+    - [Using with FlexVolume Plugin](#using-with-flexvolume-plugin)
 
 ## Troubleshooting Guide
 
@@ -42,7 +42,7 @@ kubetail longhorn-manager -n longhorn-system
 
 For the CSI driver, check the logs for `csi-attacher-0` and `csi-provisioner-0`, as well as containers in `longhorn-csi-plugin-xxx`.
 
-### Flexvolume Driver
+### FlexVolume Driver
 
 The FlexVolume driver is deprecated as of Longhorn v0.8.0 and should no longer be used.
 
@@ -67,9 +67,9 @@ touch /var/log/longhorn_driver.log
 
 ## Common Issues
 
-### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
+### A volume can be attached/detached from the UI, but Kubernetes Pods/StatefulSets cannot use it
 
-#### Using with Flexvolume Plugin
+#### Using with FlexVolume Plugin
 
 Check if the volume plugin directory has been set correctly. This is automatically detected unless the user explicitly sets it.
 

--- a/content/docs/1.12.0/troubleshoot/troubleshooting.md
+++ b/content/docs/1.12.0/troubleshoot/troubleshooting.md
@@ -7,7 +7,7 @@ weight: 1
   - [Manager and Engines](#manager-and-engines)
   - [CSI driver](#csi-driver)
   - [Flexvolume Driver](#flexvolume-driver)
-- [Common issues](#common-issues)
+- [Common Issues](#common-issues)
   - [Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it](#volume-can-be-attacheddetached-from-ui-but-kubernetes-podstatefulset-etc-cannot-use-it)
     - [Using with Flexvolume Plugin](#using-with-flexvolume-plugin)
 
@@ -23,19 +23,20 @@ See [Support Bundle](../support-bundle) for detail.
 One exception is the `dmesg`, which needs to be retrieved from each node by the user.
 
 ### UI
+
 Make use of the Longhorn UI is a good start for the troubleshooting. For example, if Kubernetes cannot mount one volume correctly, after stop the workload, try to attach and mount that volume manually on one node and access the content to check if volume is intact.
 
 Also, the event logs in the UI dashboard provides some information of probably issues. Check for the event logs in `Warning` level.
 
 ### Manager and Engines
-You can get the logs from the Longhorn Manager and Engines to help with troubleshooting. The most useful logs are the ones from `longhorn-manager-xxx`, and the logs inside Longhorn instance managers, e.g. `instance-manager-xxxx`, `instance-manager-e-xxxx` and `instance-manager-r-xxxx`.
 
-Since normally there are multiple Longhorn Managers running at the same time, we recommend using [kubetail,](https://github.com/johanhaleby/kubetail) which is a great tool to keep track of the logs of multiple pods. To track the manager logs in real time, you can use:
+You can get the logs from the Longhorn Manager and Engines to help with troubleshooting. The most useful logs are the ones from `longhorn-manager-xxx`, and the logs inside Longhorn instance managers, for example, `instance-manager-xxxx`, `instance-manager-e-xxxx` and `instance-manager-r-xxxx`.
+
+Since normally there are multiple Longhorn Managers running at the same time, we recommend using [kubetail](https://github.com/johanhaleby/kubetail), which is a great tool to keep track of the logs of multiple pods. To track the manager logs in real time, you can use:
 
 ```
 kubetail longhorn-manager -n longhorn-system
 ```
-
 
 ### CSI driver
 
@@ -47,28 +48,29 @@ The FlexVolume driver is deprecated as of Longhorn v0.8.0 and should no longer b
 
 First check where the driver has been installed on the node. Check the log of `longhorn-driver-deployer-xxxx` for that information.
 
-Then check the kubelet logs. The FlexVolume driver itself doesn't run inside the container. It would run along with the kubelet process.
+Then check the kubelet logs. The FlexVolume driver itself does not run inside the container. It would run along with the kubelet process.
 
 If kubelet is running natively on the node, you can use the following command to get the logs:
 ```
 journalctl -u kubelet
 ```
 
-Or if kubelet is running as a container (e.g. in RKE), use the following command instead:
+Or if kubelet is running as a container (for example, in RKE), use the following command instead:
 ```
 docker logs kubelet
 ```
 
-For even more detailed logs of Longhorn FlexVolume, run the following command on the node or inside the container (if kubelet is running as a container, e.g. in RKE):
+For even more detailed logs of Longhorn FlexVolume, run the following command on the node or inside the container (if kubelet is running as a container, for example, in RKE):
 ```
 touch /var/log/longhorn_driver.log
 ```
 
+## Common Issues
 
-## Common issues
 ### Volume can be attached/detached from UI, but Kubernetes Pod/StatefulSet etc cannot use it
 
 #### Using with Flexvolume Plugin
+
 Check if the volume plugin directory has been set correctly. This is automatically detected unless the user explicitly sets it.
 
 By default, Kubernetes uses `/usr/libexec/kubernetes/kubelet-plugins/volume/exec/`, as stated in the [official document](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-storage/flexvolume.md/#prerequisites).
@@ -111,3 +113,9 @@ To enable profiling, you can:
 
     Profiler is disabled!
     ```
+
+### SPDK - Failed to bind NVMe disk (Error -22)
+
+If `instance-manager` logs show `failed to bind NVMe disk` or `vfio-pci: probe ... failed with error -22`, your NVMe likely shares an IOMMU group with a PCIe bridge.
+
+**Validation**: Run `lspci -t` or check `/sys/kernel/iommu_groups/`. If the NVMe and Bridge are in the same group, you must switch the disk to **AIO mode** in the Longhorn UI.

--- a/content/docs/1.12.0/v2-data-engine/prerequisites.md
+++ b/content/docs/1.12.0/v2-data-engine/prerequisites.md
@@ -44,7 +44,6 @@ When the V2 Data Engine is enabled, each instance-manager pod utilizes **1 CPU c
 
 SPDK leverages huge pages for enhancing performance and minimizing memory overhead. You must configure 2 MiB-sized huge pages on each Longhorn node to enable usage of huge pages. Specifically, 1024 pages (equivalent to a total of 2 GiB) must be available on each Longhorn node.
 
-
 ### Disk
 
 SPDK leverages kernel drivers to support every kind of disk that Linux supports. However, SPDK is equipped with a user space NVMe driver that provides zero-copy, highly parallel, direct access to an SSD from a user space application. Because of this, using **local NVMe disks** is highly recommended for enabling V2 volumes to achieve optimal storage performance.

--- a/content/docs/1.12.0/v2-data-engine/prerequisites.md
+++ b/content/docs/1.12.0/v2-data-engine/prerequisites.md
@@ -48,3 +48,11 @@ SPDK leverages huge pages for enhancing performance and minimizing memory overhe
 ### Disk
 
 SPDK leverages kernel drivers to support every kind of disk that Linux supports. However, SPDK is equipped with a user space NVMe driver that provides zero-copy, highly parallel, direct access to an SSD from a user space application. Because of this, using **local NVMe disks** is highly recommended for enabling V2 volumes to achieve optimal storage performance.
+
+### IOMMU Group Isolation Requirement
+
+For the V2 Data Engine (SPDK) to claim a disk, the NVMe device must be isolatable. Because SPDK uses `vfio-pci`, the following hardware constraints apply:
+
+- **Group Ownership**: VFIO must claim the *entire* IOMMU group. If a group contains multiple devices (for example, an NVMe drive and a PCIe Bridge), all devices in that group must be bound to VFIO.
+- **Bridge Limitation**: The Linux kernel does not allow binding a PCIe Bridge or Switch Port to the `vfio-pci` driver.
+- **The Conflict**: If your hardware topology places an NVMe device in the same IOMMU group as its parent PCIe Bridge, SPDK cannot initialize the device. In these cases, the disk must be used in **AIO mode**.


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

[Issue 12709](https://github.com/longhorn/longhorn/issues/12709)

#### What this PR does / why we need it:

Adds documentation regarding IOMMU group isolation requirements for the V2 Data Engine (SPDK) to clarify why initialization fails when NVMe devices share groups with PCIe bridges.

#### Special notes for your reviewer:

This address a hardware-level limitation where `vfio-pci` cannot claim a disk if its parent bridge is in the same IOMMU group, a common issue reported by Talos Linux users.

#### Additional documentation or context:

N/A