### PR TITLE
📖 Add KubeStellar Console guided install reference

### DIFF
--- a/content/docs/1.12.0/deploy/install/_index.md
+++ b/content/docs/1.12.0/deploy/install/_index.md
@@ -33,6 +33,10 @@ Longhorn can be installed on a Kubernetes cluster in several ways:
 
 To install Longhorn in an air gapped environment, refer to [Air Gap Installation](../install/airgap).
 
+### Community Tools
+
+- [KubeStellar Console Guided Install](./install-with-kubestellar-console) — A step-by-step guided installation experience with pre-flight checks, progress tracking, and validation.
+
 For information on customizing Longhorn's default settings, refer to [Customizing Default Settings](../../advanced-resources/deploy/customizing-default-settings).
 
 For information on deploying Longhorn on specific nodes and rejecting general workloads for those nodes, refer to the section on [Taints and Tolerations](../../advanced-resources/deploy/taint-toleration).

--- a/content/docs/1.12.0/deploy/install/install-with-kubestellar-console.md
+++ b/content/docs/1.12.0/deploy/install/install-with-kubestellar-console.md
@@ -3,7 +3,7 @@ title: Install with KubeStellar Console
 weight: 14
 ---
 
-[KubeStellar Console](https://console.kubestellar.io) is an open-source Kubernetes dashboard that provides guided installation missions for CNCF projects, including Longhorn.
+[KubeStellar Console](https://console.kubestellar.io) is an open source Kubernetes dashboard that provides guided installation missions for CNCF projects, including Longhorn.
 
 The guided install mission walks you through the entire Longhorn installation process with:
 
@@ -24,5 +24,5 @@ The mission installs Longhorn using Helm, similar to the [Install with Helm](./i
 
 ## More Information
 
-- [KubeStellar Console](https://console.kubestellar.io) — Open-source Kubernetes dashboard
+- [KubeStellar Console](https://console.kubestellar.io) — Open source Kubernetes dashboard
 - [Mission source](https://github.com/kubestellar/console-kb/blob/master/fixes/cncf-install/install-longhorn.json) — The mission definition is open source and maintained by the KubeStellar community

--- a/content/docs/1.12.0/deploy/install/install-with-kubestellar-console.md
+++ b/content/docs/1.12.0/deploy/install/install-with-kubestellar-console.md
@@ -25,4 +25,4 @@ The mission installs Longhorn using Helm, similar to the [Install with Helm](./i
 ## More Information
 
 - [KubeStellar Console](https://console.kubestellar.io) — Open-source Kubernetes dashboard
-- [Mission source](https://github.com/kubestellar/console-kb/blob/master/solutions/cncf-install/install-longhorn.json) — The mission definition is open source and maintained by the KubeStellar community
+- [Mission source](https://github.com/kubestellar/console-kb/blob/master/fixes/cncf-install/install-longhorn.json) — The mission definition is open source and maintained by the KubeStellar community

--- a/content/docs/1.12.0/deploy/install/install-with-kubestellar-console.md
+++ b/content/docs/1.12.0/deploy/install/install-with-kubestellar-console.md
@@ -1,0 +1,28 @@
+---
+title: Install with KubeStellar Console
+weight: 14
+---
+
+[KubeStellar Console](https://console.kubestellar.io) is an open-source Kubernetes dashboard that provides guided installation missions for CNCF projects, including Longhorn.
+
+The guided install mission walks you through the entire Longhorn installation process with:
+
+- **Pre-flight checks**: Automatically verifies that your cluster meets Longhorn's [installation requirements](../#installation-requirements) before proceeding.
+- **Step-by-step guidance**: Each installation step is presented with clear instructions and expected outcomes.
+- **Progress tracking**: Visual progress indicators show your current position in the installation workflow.
+- **Validation**: Post-install checks confirm that Longhorn components are running correctly.
+
+> **Note**: Longhorn does not support downgrading. The guided install follows a forward-only upgrade path consistent with Longhorn's requirements.
+
+## Using the Guided Install
+
+1. Open the [Longhorn install mission](https://console.kubestellar.io/missions/install-longhorn) in KubeStellar Console.
+2. Connect your Kubernetes cluster.
+3. Follow the guided steps to complete the installation.
+
+The mission installs Longhorn using Helm, similar to the [Install with Helm](./install-with-helm) method.
+
+## More Information
+
+- [KubeStellar Console](https://console.kubestellar.io) — Open-source Kubernetes dashboard
+- [Mission source](https://github.com/kubestellar/console-kb/blob/master/solutions/cncf-install/install-longhorn.json) — The mission definition is open source and maintained by the KubeStellar community


### PR DESCRIPTION
## Summary

- Adds a "Community Tools" subsection to the installation overview page (`deploy/install/_index.md`) with a link to the KubeStellar Console guided install mission
- Adds a dedicated `install-with-kubestellar-console.md` page describing the guided install experience (pre-flight checks, step-by-step guidance, progress tracking, and validation)
- Notes that Longhorn does not support downgrading, consistent with feedback from @PhanLe1010 on longhorn/longhorn#12809

## Context

On longhorn/longhorn#12809, Longhorn maintainers (@derekbit, @PhanLe1010) engaged with the KubeStellar Console guided install mission and provided feedback that has been incorporated (removing rollback steps since Longhorn requires forward-only upgrades).

[KubeStellar Console](https://console.kubestellar.io) is an open-source Kubernetes dashboard that provides guided installation missions for CNCF projects. The [Longhorn install mission](https://console.kubestellar.io/missions/install-longhorn) walks users through the entire installation with pre-flight checks and validation.

## Changes

- `content/docs/1.12.0/deploy/install/_index.md` — Added "Community Tools" subsection after the official install methods
- `content/docs/1.12.0/deploy/install/install-with-kubestellar-console.md` — New page with guided install details

## Test plan

- [ ] Verify the site builds locally with `hugo server --buildDrafts --buildFuture`
- [ ] Confirm the new page renders correctly and links work
- [ ] Verify the Community Tools section appears in the install overview