### PR TITLE
Fix relative links in nginx retirement notice

### DIFF
--- a/content/docs/1.12.0/deploy/accessing-the-ui/longhorn-ingress.md
+++ b/content/docs/1.12.0/deploy/accessing-the-ui/longhorn-ingress.md
@@ -7,8 +7,8 @@
 >
 > **Recommended Alternatives**:
 > To ensure continued support and security, we recommend using one of the following methods to expose the Longhorn UI:
->   * **Traefik Ingress**: The current default for RKE2/K3s environments. See [Create an Ingress with Traefik](./longhorn-ingress-traefik).
->   * **Gateway API**: The modern, successor to Ingress for advanced routing. See [Create an HTTPRoute with Gateway API](./longhorn-httproute).
+>   * **Traefik Ingress**: The current default for RKE2/K3s environments. See [Create an Ingress with Traefik](../longhorn-ingress-traefik).
+>   * **Gateway API**: The modern, successor to Ingress for advanced routing. See [Create an HTTPRoute with Gateway API](../longhorn-httproute).
 
 If you install Longhorn on a Kubernetes cluster with kubectl or Helm, you will need to create an Ingress to allow external traffic to reach the Longhorn UI.
 


### PR DESCRIPTION
Updated links for Traefik Ingress and Gateway API in the Longhorn Ingress documentation to reflect the correct relative paths.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/12904

#### What this PR does / why we need it:
The links in the deprecation notice in the docs page [Create an Ingress with Basic Authentication](https://longhorn.io/docs/1.12.0/deploy/accessing-the-ui/longhorn-ingress/) are broken. This PR fixes them.

#### Special notes for your reviewer:

#### Additional documentation or context
