### PR TITLE
docs: Graceful Node Removal guide

### DIFF
--- a/content/docs/1.12.0/nodes-and-volumes/nodes/graceful-node-removal.md
+++ b/content/docs/1.12.0/nodes-and-volumes/nodes/graceful-node-removal.md
@@ -1,0 +1,75 @@
+---
+title: Graceful Node Removal
+weight: 7
+---
+
+Removing a node from a Kubernetes cluster requires careful coordination with Longhorn to ensure data availability. Simply running `kubectl delete node` is insufficient because Kubernetes does not automatically notify CSI storage layers to migrate data replicas before the node is destroyed.
+
+If a node is removed without following this procedure, the replicas stored on that node will be lost, potentially leaving your volumes in a **Degraded** or **Faulted** state.
+
+## Prerequisites
+
+- The cluster must have enough available space and schedulable nodes to receive the replicas being moved.
+- Verify volume health: Ensure no volumes are currently `Degraded` before starting.
+
+## Step-by-Step Procedure
+
+### 1. Cordon and Drain the Kubernetes Node
+
+Prepare the node for removal by moving all running workloads (Pods) to other nodes.
+
+```bash
+kubectl cordon <NODE_NAME>
+kubectl drain <NODE_NAME> --ignore-daemonsets --delete-emptydir-data
+```
+
+### 2. Disable Scheduling in Longhorn
+
+Prevent Longhorn from attempting to schedule new replicas onto this node.
+
+1. Open the Longhorn UI and navigate to the **Node** tab.
+2. Select the node and click **Edit Node and Disks**.
+3. Set **Scheduling** to **Disable**.
+4. Click **Save**.
+
+### 3. Trigger Node Eviction
+
+Evict existing replicas to other healthy nodes.
+
+1. In the **Edit Node** dialog, set **Eviction Requested** to **true**.
+2. Click **Save**.
+3. **Monitor Progress**: In the **Node** list, watch the **Replicas** column. Wait until the count reaches **0**.
+
+> **Note**: This process works for both `Attached` and `Detached` volumes. Longhorn will automatically attach detached volumes to migrate data and detach them when finished. To maintain high availability, Longhorn only deletes the old replica after the new replica has successfully finished rebuilding.
+
+### 4. Delete the Kubernetes Node
+
+Remove the node resource from the Kubernetes cluster. Longhorn requires the Kubernetes node to be removed before it will allow the deletion of the Longhorn Node resource.
+
+```bash
+kubectl delete node <NODE_NAME>
+```
+
+### 5. Delete the Longhorn Node
+
+Once the Kubernetes node is deleted, the Longhorn UI will show the node in a **Down** state. You can now safely remove the metadata.
+
+- **Via UI**: In the **Node** tab, the **Remove** button for the node will now be enabled. Click **Remove**.
+- **Via CLI**: If you prefer using `kubectl`, you can delete the Longhorn Node resource directly using the following command:    
+    ```bash
+    kubectl -n longhorn-system delete nodes.longhorn.io <NODE_NAME>
+    ```
+
+## Troubleshooting
+
+### Node "Remove" button is greyed out
+
+The UI disables the **Remove** button if the corresponding Kubernetes node still exists. Ensure you have successfully executed `kubectl delete node <NODE_NAME>` first.
+
+### Eviction is stuck
+
+If the replica count does not reach 0, check the **Events** log. Common causes include:
+
+- **Insufficient Space**: No other nodes have enough disk space to house the replicas.
+- **Anti-Affinity Constraints**: If `Replica Node Level Soft Anti-Affinity` is disabled, and all other nodes already host a replica of the same volume, the eviction will have no valid destination.
+- **Volume Health**: Rebuilding cannot start if the volume is already in a `Faulted` state.

--- a/content/docs/1.12.0/nodes-and-volumes/nodes/graceful-node-removal.md
+++ b/content/docs/1.12.0/nodes-and-volumes/nodes/graceful-node-removal.md
@@ -16,12 +16,19 @@ If a node is removed without following this procedure, the replicas stored on th
 
 ### 1. Cordon and Drain the Kubernetes Node
 
-Prepare the node for removal by moving all running workloads (Pods) to other nodes.
+Prepare the node for removal by moving all running workloads (Pods) to other nodes. Using a timeout and force flag ensures that the drain completes even if some pods are slow to terminate or protected by Pod Disruption Budgets.
 
 ```bash
 kubectl cordon <NODE_NAME>
-kubectl drain <NODE_NAME> --ignore-daemonsets --delete-emptydir-data
+kubectl drain <NODE_NAME> \
+  --ignore-daemonsets \
+  --delete-emptydir-data \
+  --force \
+  --grace-period=-1 \
+  --timeout=300s
 ```
+
+> **Note**: The `--grace-period=-1` flag allows pods to honor their own `terminationGracePeriodSeconds`. The `--force` flag is necessary to remove pods that are not managed by a ReplicationController, ReplicaSet, Job, DaemonSet, or StatefulSet.
 
 ### 2. Disable Scheduling and Trigger Eviction
 
@@ -47,7 +54,7 @@ kubectl patch node.longhorn.io <NODE_NAME> \
 
 ### 3. Monitor Eviction Progress
 
-Before proceeding to delete the node, you must ensure all data has successfully migrated.
+Before proceeding to delete the node, you must ensure all replicas has successfully migrated.
 
 * **Via UI**: In the **Nodes** list, watch the **Replicas** column for the node. Wait until the count reaches **0**.
 * **Via CLI**: Poll the node status to confirm all resources (Replicas and Backing Images) have migrated:
@@ -90,6 +97,6 @@ The UI disables the **Delete** button if the corresponding Kubernetes node still
 
 If the replica count does not reach 0, check the **Events** log. Common causes include:
 
-- **Insufficient Space**: No other nodes have enough disk space to house the replicas.
-- **Anti-Affinity Constraints**: If `Replica Node Level Soft Anti-Affinity` is disabled, and all other nodes already host a replica of the same volume, the eviction will have no valid destination.
-- **Volume Health**: Rebuilding cannot start if the volume is already in a `Faulted` state.
+- **Insufficient Space**: No other nodes have enough disk space to house the replicas. To recover from this, you can refer to [Manual Recovery of Nodes with Insufficient Space](../../../../kb/manual-recovery-of-nodes-with-insufficient-space).
+- **Anti-Affinity Constraints**: If `Replica Node Level Soft Anti-Affinity` is disabled, and all other nodes already host a replica of the same volume, the eviction will have no valid destination. To learn more about anti-affinity and how to resolve this, see [Replica Scheduling and Anti-Affinity](../../best-practices.md#replica-node-level-soft-anti-affinity).
+- **Volume Health**: Rebuilding cannot start if the volume is already in a `Faulted` state. To learn more volume and volume health, refer to [Volume documentation](../volumes/create-volumes).

--- a/content/docs/1.12.0/nodes-and-volumes/nodes/graceful-node-removal.md
+++ b/content/docs/1.12.0/nodes-and-volumes/nodes/graceful-node-removal.md
@@ -27,9 +27,9 @@ kubectl drain <NODE_NAME> --ignore-daemonsets --delete-emptydir-data
 
 Prevent Longhorn from attempting to schedule new replicas onto this node.
 
-1. Open the Longhorn UI and navigate to the **Node** tab.
-2. Select the node and click **Edit Node and Disks**.
-3. Set **Scheduling** to **Disable**.
+1. Open the Longhorn UI and navigate to the **Nodes** tab.
+2. Select the node and click **Edit Node** button.
+3. Set **Node Scheduling** to **Disable**.
 4. Click **Save**.
 
 ### 3. Trigger Node Eviction
@@ -38,7 +38,7 @@ Evict existing replicas to other healthy nodes.
 
 1. In the **Edit Node** dialog, set **Eviction Requested** to **true**.
 2. Click **Save**.
-3. **Monitor Progress**: In the **Node** list, watch the **Replicas** column. Wait until the count reaches **0**.
+3. **Monitor Progress**: In the nodes list, watch the **Replicas** column. Wait until the count reaches **0**.
 
 > **Note**: This process works for both `Attached` and `Detached` volumes. Longhorn will automatically attach detached volumes to migrate data and detach them when finished. To maintain high availability, Longhorn only deletes the old replica after the new replica has successfully finished rebuilding.
 
@@ -54,7 +54,7 @@ kubectl delete node <NODE_NAME>
 
 Once the Kubernetes node is deleted, the Longhorn UI will show the node in a **Down** state. You can now safely remove the metadata.
 
-- **Via UI**: In the **Node** tab, the **Remove** button for the node will now be enabled. Click **Remove**.
+- **Via UI**: In the **Nodes** tab, the **Delete** button for the node will now be enabled. Click **Delete**.
 - **Via CLI**: If you prefer using `kubectl`, you can delete the Longhorn Node resource directly using the following command:    
     ```bash
     kubectl -n longhorn-system delete nodes.longhorn.io <NODE_NAME>
@@ -62,9 +62,9 @@ Once the Kubernetes node is deleted, the Longhorn UI will show the node in a **D
 
 ## Troubleshooting
 
-### Node "Remove" button is greyed out
+### Node "Delete" button is greyed out
 
-The UI disables the **Remove** button if the corresponding Kubernetes node still exists. Ensure you have successfully executed `kubectl delete node <NODE_NAME>` first.
+The UI disables the **Delete** button if the corresponding Kubernetes node still exists. Ensure you have successfully executed `kubectl delete node <NODE_NAME>` first.
 
 ### Eviction is stuck
 

--- a/content/docs/1.12.0/nodes-and-volumes/nodes/graceful-node-removal.md
+++ b/content/docs/1.12.0/nodes-and-volumes/nodes/graceful-node-removal.md
@@ -23,24 +23,44 @@ kubectl cordon <NODE_NAME>
 kubectl drain <NODE_NAME> --ignore-daemonsets --delete-emptydir-data
 ```
 
-### 2. Disable Scheduling in Longhorn
+### 2. Disable Scheduling and Trigger Eviction
 
-Prevent Longhorn from attempting to schedule new replicas onto this node.
+You must prevent new data from being scheduled on the node and move existing data to other healthy nodes. This can be done via the Longhorn UI or the command line.
+
+#### Via Longhorn UI
 
 1. Open the Longhorn UI and navigate to the **Nodes** tab.
-2. Select the node and click **Edit Node** button.
+2. Select the node and click the **Edit Node** button.
 3. Set **Node Scheduling** to **Disable**.
-4. Click **Save**.
+4. Set **Eviction Requested** to **true**.
+5. Click **Save**.
 
-### 3. Trigger Node Eviction
+#### Via kubectl
 
-Evict existing replicas to other healthy nodes.
+Patch the Longhorn Node CR to disable scheduling and request eviction in a single command:
 
-1. In the **Edit Node** dialog, set **Eviction Requested** to **true**.
-2. Click **Save**.
-3. **Monitor Progress**: In the nodes list, watch the **Replicas** column. Wait until the count reaches **0**.
+```bash
+kubectl patch node.longhorn.io <NODE_NAME> \
+  -n longhorn-system --type=merge \
+  -p '{"spec":{"allowScheduling":false,"evictionRequested":true}}'
+```
 
-> **Note**: This process works for both `Attached` and `Detached` volumes. Longhorn will automatically attach detached volumes to migrate data and detach them when finished. To maintain high availability, Longhorn only deletes the old replica after the new replica has successfully finished rebuilding.
+### 3. Monitor Eviction Progress
+
+Before proceeding to delete the node, you must ensure all data has successfully migrated.
+
+* **Via UI**: In the **Nodes** list, watch the **Replicas** column for the node. Wait until the count reaches **0**.
+* **Via CLI**: Poll the node status to confirm all resources (Replicas and Backing Images) have migrated:
+
+    ```bash
+    kubectl get node.longhorn.io <NODE_NAME> -n longhorn-system -o json \
+    | jq '.status.diskStatus | to_entries[]
+            | {disk: .key,
+            scheduledReplicas: (.value.scheduledReplica | length),
+            scheduledBackingImages: (.value.scheduledBackingImage | length)}'
+    ```
+
+> **Note**: Eviction is complete only when every disk reports `scheduledReplicas: 0` and `scheduledBackingImages: 0`. This process works for both `Attached` and `Detached` volumes. Longhorn will automatically attach detached volumes to migrate data and detach them when finished.
 
 ### 4. Delete the Kubernetes Node
 

--- a/content/docs/1.12.0/nodes-and-volumes/nodes/graceful-node-removal.md
+++ b/content/docs/1.12.0/nodes-and-volumes/nodes/graceful-node-removal.md
@@ -10,7 +10,6 @@ If a node is removed without following this procedure, the replicas stored on th
 ## Prerequisites
 
 - The cluster must have enough available space and schedulable nodes to receive the replicas being moved.
-- Verify volume health: Ensure no volumes are currently `Degraded` before starting.
 
 ## Step-by-Step Procedure
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

[Issue 12961](https://github.com/longhorn/longhorn/issues/12961)

#### What this PR does / why we need it:

This PR introduces a Graceful Node Removal guide to the Longhorn documentation. Its primary purpose is to prevent data loss by establishing a mandatory sequence of operations for decommissioning a node. It addresses a specific gap where Kubernetes' native "drain" and "delete" commands do not automatically trigger the migration of Longhorn data replicas.

#### Special notes for your reviewer:

N/A

#### Additional documentation or context:

N/A
