### PR TITLE
docs(setting): update DataEngineCPUMask description and default to recommend 2+ cores

### DIFF
--- a/content/docs/1.12.0/references/settings.md
+++ b/content/docs/1.12.0/references/settings.md
@@ -1270,9 +1270,9 @@ In seconds. The setting specifies the timeout for the instance manager pod liven
 
 #### Data Engine CPU Mask
 
-> Default: `{"v2":"0x1"}`
+> Default: `{"v2":"0x3"}`
 
-Applies only to the V2 Data Engine. Specifies the CPU cores on which the Storage Performance Development Kit (SPDK) target daemon runs. The daemon is deployed in each Instance Manager pod. Ensure that the number of assigned cores does not exceed the guaranteed Instance Manager CPUs for the V2 Data Engine. Accepts hex mask format (e.g., 0x1, 0xff) or CPU list format (e.g., 1-3,5,7). CPU list format is automatically converted to hex mask. The default value is 0x1.
+Applies only to the V2 Data Engine. Specifies the CPU cores on which the Storage Performance Development Kit (SPDK) target daemon runs. The daemon is deployed in each Instance Manager pod. Ensure that the assigned CPU cores do not exceed the guaranteed CPUs allocated to the V2 Data Engine Instance Manager. A minimum of 2 CPU cores is recommended. SPDK uses a busy-polling reactor model where the master reactor handles both I/O polling and management RPCs. When only a single core is assigned, heavy I/O workloads can delay or starve RPC processing, resulting in increased latency, timeout events, and operational instability. Assigning 2 or more cores allows I/O and management tasks to run on separate reactors, improving responsiveness and operational stability. Accepts either hexadecimal CPU masks (for example, 0x3 or 0xff) or CPU list format (for example, 0-1,2,5). CPU lists are automatically converted to hexadecimal masks. The default value is 0x3.
 
 #### Data Engine Hugepage Enabled
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue # longhorn/longhorn#13237

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
