### PR TITLE
Updated helm install command

### DIFF
--- a/content/docs/1.11.0/advanced-resources/os-distro-specific/okd-support.md
+++ b/content/docs/1.11.0/advanced-resources/os-distro-specific/okd-support.md
@@ -29,7 +29,8 @@ Install Longhorn with the following settings:
 | Setting | Value | Example |
 | --- | --- | --- |
 | `openshift.enabled` | `true` | N/A |
-| `image.openshift.oauthProxy.repository` | Upstream image | `quay.io/openshift/origin-oauth-proxy` |
+| `image.openshift.oauthProxy.registry` | Container registry | `quay.io` |
+| `image.openshift.oauthProxy.repository` | Upstream image | `openshift/origin-oauth-proxy` |
 | `image.openshift.oauthProxy.tag` | Version 4.1 or later | `4.18` |
 
 ```bash
@@ -37,7 +38,8 @@ Install Longhorn with the following settings:
     --namespace longhorn-system \
     --create-namespace \
     --set openshift.enabled=true \
-    --set image.openshift.oauthProxy.repository=quay.io/openshift/origin-oauth-proxy \
+    --set image.openshift.oauthProxy.registry=quay.io \
+    --set image.openshift.oauthProxy.repository=openshift/origin-oauth-proxy \
     --set image.openshift.oauthProxy.tag=4.18
 ```
 

--- a/content/docs/1.11.1/advanced-resources/os-distro-specific/okd-support.md
+++ b/content/docs/1.11.1/advanced-resources/os-distro-specific/okd-support.md
@@ -29,7 +29,8 @@ Install Longhorn with the following settings:
 | Setting | Value | Example |
 | --- | --- | --- |
 | `openshift.enabled` | `true` | N/A |
-| `image.openshift.oauthProxy.repository` | Upstream image | `quay.io/openshift/origin-oauth-proxy` |
+| `image.openshift.oauthProxy.registry` | Container registry | `quay.io` |
+| `image.openshift.oauthProxy.repository` | Upstream image | `openshift/origin-oauth-proxy` |
 | `image.openshift.oauthProxy.tag` | Version 4.1 or later | `4.18` |
 
 ```bash
@@ -37,7 +38,8 @@ Install Longhorn with the following settings:
     --namespace longhorn-system \
     --create-namespace \
     --set openshift.enabled=true \
-    --set image.openshift.oauthProxy.repository=quay.io/openshift/origin-oauth-proxy \
+    --set image.openshift.oauthProxy.registry=quay.io \
+    --set image.openshift.oauthProxy.repository=openshift/origin-oauth-proxy \
     --set image.openshift.oauthProxy.tag=4.18
 ```
 

--- a/content/docs/1.11.2/advanced-resources/os-distro-specific/okd-support.md
+++ b/content/docs/1.11.2/advanced-resources/os-distro-specific/okd-support.md
@@ -29,7 +29,8 @@ Install Longhorn with the following settings:
 | Setting | Value | Example |
 | --- | --- | --- |
 | `openshift.enabled` | `true` | N/A |
-| `image.openshift.oauthProxy.repository` | Upstream image | `quay.io/openshift/origin-oauth-proxy` |
+| `image.openshift.oauthProxy.registry` | Container registry | `quay.io` |
+| `image.openshift.oauthProxy.repository` | Upstream image | `openshift/origin-oauth-proxy` |
 | `image.openshift.oauthProxy.tag` | Version 4.1 or later | `4.18` |
 
 ```bash
@@ -37,7 +38,8 @@ Install Longhorn with the following settings:
     --namespace longhorn-system \
     --create-namespace \
     --set openshift.enabled=true \
-    --set image.openshift.oauthProxy.repository=quay.io/openshift/origin-oauth-proxy \
+    --set image.openshift.oauthProxy.registry=quay.io \
+    --set image.openshift.oauthProxy.repository=openshift/origin-oauth-proxy \
     --set image.openshift.oauthProxy.tag=4.18
 ```
 

--- a/content/docs/1.11.3/advanced-resources/os-distro-specific/okd-support.md
+++ b/content/docs/1.11.3/advanced-resources/os-distro-specific/okd-support.md
@@ -29,7 +29,8 @@ Install Longhorn with the following settings:
 | Setting | Value | Example |
 | --- | --- | --- |
 | `openshift.enabled` | `true` | N/A |
-| `image.openshift.oauthProxy.repository` | Upstream image | `quay.io/openshift/origin-oauth-proxy` |
+| `image.openshift.oauthProxy.registry` | Container registry | `quay.io` |
+| `image.openshift.oauthProxy.repository` | Upstream image | `openshift/origin-oauth-proxy` |
 | `image.openshift.oauthProxy.tag` | Version 4.1 or later | `4.18` |
 
 ```bash
@@ -37,7 +38,8 @@ Install Longhorn with the following settings:
     --namespace longhorn-system \
     --create-namespace \
     --set openshift.enabled=true \
-    --set image.openshift.oauthProxy.repository=quay.io/openshift/origin-oauth-proxy \
+    --set image.openshift.oauthProxy.registry=quay.io \
+    --set image.openshift.oauthProxy.repository=openshift/origin-oauth-proxy \
     --set image.openshift.oauthProxy.tag=4.18
 ```
 

--- a/content/docs/1.12.0/advanced-resources/os-distro-specific/okd-support.md
+++ b/content/docs/1.12.0/advanced-resources/os-distro-specific/okd-support.md
@@ -29,7 +29,8 @@ Install Longhorn with the following settings:
 | Setting | Value | Example |
 | --- | --- | --- |
 | `openshift.enabled` | `true` | N/A |
-| `image.openshift.oauthProxy.repository` | Upstream image | `quay.io/openshift/origin-oauth-proxy` |
+| `image.openshift.oauthProxy.registry` | Container registry | `quay.io` |
+| `image.openshift.oauthProxy.repository` | Upstream image | `openshift/origin-oauth-proxy` |
 | `image.openshift.oauthProxy.tag` | Version 4.1 or later | `4.18` |
 
 ```bash
@@ -37,7 +38,8 @@ Install Longhorn with the following settings:
     --namespace longhorn-system \
     --create-namespace \
     --set openshift.enabled=true \
-    --set image.openshift.oauthProxy.repository=quay.io/openshift/origin-oauth-proxy \
+    --set image.openshift.oauthProxy.registry=quay.io \
+    --set image.openshift.oauthProxy.repository=openshift/origin-oauth-proxy \
     --set image.openshift.oauthProxy.tag=4.18
 ```
 

--- a/content/docs/1.12.1/advanced-resources/os-distro-specific/okd-support.md
+++ b/content/docs/1.12.1/advanced-resources/os-distro-specific/okd-support.md
@@ -29,7 +29,8 @@ Install Longhorn with the following settings:
 | Setting | Value | Example |
 | --- | --- | --- |
 | `openshift.enabled` | `true` | N/A |
-| `image.openshift.oauthProxy.repository` | Upstream image | `quay.io/openshift/origin-oauth-proxy` |
+| `image.openshift.oauthProxy.registry` | Container registry | `quay.io` |
+| `image.openshift.oauthProxy.repository` | Upstream image | `openshift/origin-oauth-proxy` |
 | `image.openshift.oauthProxy.tag` | Version 4.1 or later | `4.18` |
 
 ```bash
@@ -37,7 +38,8 @@ Install Longhorn with the following settings:
     --namespace longhorn-system \
     --create-namespace \
     --set openshift.enabled=true \
-    --set image.openshift.oauthProxy.repository=quay.io/openshift/origin-oauth-proxy \
+    --set image.openshift.oauthProxy.registry=quay.io \
+    --set image.openshift.oauthProxy.repository=openshift/origin-oauth-proxy \
     --set image.openshift.oauthProxy.tag=4.18
 ```
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/13339

#### What this PR does / why we need it:

This PR fixes an error in the Helm install command that caused the `longhorn-ui` OAuth proxy container image path to be generated incorrectly.
