### PR TITLE
docs: use settings.longhorn.io in archives and KB

### DIFF
--- a/content/docs/archives/1.2.3/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.2.3/advanced-resources/deploy/customizing-default-settings.md
@@ -168,7 +168,7 @@ It would make the setting persistent.
 If you prefer to use the command line to update the setting, you could use kubectl.
 But please be aware **this will bypass Longhorn backend validation**.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Script

--- a/content/docs/archives/1.2.4/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.2.4/advanced-resources/deploy/customizing-default-settings.md
@@ -168,7 +168,7 @@ It would make the setting persistent.
 If you prefer to use the command line to update the setting, you could use kubectl.
 But please be aware **this will bypass Longhorn backend validation**.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Script

--- a/content/docs/archives/1.2.5/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.2.5/advanced-resources/deploy/customizing-default-settings.md
@@ -168,7 +168,7 @@ It would make the setting persistent.
 If you prefer to use the command line to update the setting, you could use kubectl.
 But please be aware **this will bypass Longhorn backend validation**.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Script

--- a/content/docs/archives/1.2.6/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.2.6/advanced-resources/deploy/customizing-default-settings.md
@@ -168,7 +168,7 @@ It would make the setting persistent.
 If you prefer to use the command line to update the setting, you could use kubectl.
 But please be aware **this will bypass Longhorn backend validation**.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Script

--- a/content/docs/archives/1.3.0/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.3.0/advanced-resources/deploy/customizing-default-settings.md
@@ -186,8 +186,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.3.1/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.3.1/advanced-resources/deploy/customizing-default-settings.md
@@ -170,7 +170,7 @@ It would make the setting persistent.
 If you prefer to use the command line to update the setting, you could use kubectl.
 But please be aware **this will bypass Longhorn backend validation**.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Script

--- a/content/docs/archives/1.3.2/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.3.2/advanced-resources/deploy/customizing-default-settings.md
@@ -170,7 +170,7 @@ It would make the setting persistent.
 If you prefer to use the command line to update the setting, you could use kubectl.
 But please be aware **this will bypass Longhorn backend validation**.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Script

--- a/content/docs/archives/1.3.3/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.3.3/advanced-resources/deploy/customizing-default-settings.md
@@ -170,7 +170,7 @@ It would make the setting persistent.
 If you prefer to use the command line to update the setting, you could use kubectl.
 But please be aware **this will bypass Longhorn backend validation**.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Script

--- a/content/docs/archives/1.3.4/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.3.4/advanced-resources/deploy/customizing-default-settings.md
@@ -170,7 +170,7 @@ It would make the setting persistent.
 If you prefer to use the command line to update the setting, you could use kubectl.
 But please be aware **this will bypass Longhorn backend validation**.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Script

--- a/content/docs/archives/1.4.0/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.4.0/advanced-resources/deploy/customizing-default-settings.md
@@ -188,8 +188,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.4.1/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.4.1/advanced-resources/deploy/customizing-default-settings.md
@@ -175,8 +175,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.4.2/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.4.2/advanced-resources/deploy/customizing-default-settings.md
@@ -175,8 +175,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.4.3/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.4.3/advanced-resources/deploy/customizing-default-settings.md
@@ -175,8 +175,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.4.4/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.4.4/advanced-resources/deploy/customizing-default-settings.md
@@ -175,8 +175,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.5.0/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.5.0/advanced-resources/deploy/customizing-default-settings.md
@@ -170,8 +170,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.5.1/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.5.1/advanced-resources/deploy/customizing-default-settings.md
@@ -170,8 +170,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.5.2/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.5.2/advanced-resources/deploy/customizing-default-settings.md
@@ -170,8 +170,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.5.3/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.5.3/advanced-resources/deploy/customizing-default-settings.md
@@ -170,8 +170,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.5.4/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.5.4/advanced-resources/deploy/customizing-default-settings.md
@@ -170,8 +170,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.5.5/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.5.5/advanced-resources/deploy/customizing-default-settings.md
@@ -170,8 +170,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.5.6/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.5.6/advanced-resources/deploy/customizing-default-settings.md
@@ -170,8 +170,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.6.0/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.6.0/advanced-resources/deploy/customizing-default-settings.md
@@ -187,8 +187,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.6.1/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.6.1/advanced-resources/deploy/customizing-default-settings.md
@@ -187,8 +187,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.6.2/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.6.2/advanced-resources/deploy/customizing-default-settings.md
@@ -187,8 +187,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.6.3/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.6.3/advanced-resources/deploy/customizing-default-settings.md
@@ -187,8 +187,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.6.4/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.6.4/advanced-resources/deploy/customizing-default-settings.md
@@ -187,8 +187,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.6.5/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.6.5/advanced-resources/deploy/customizing-default-settings.md
@@ -187,8 +187,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.7.0/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.7.0/advanced-resources/deploy/customizing-default-settings.md
@@ -187,8 +187,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.7.1/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.7.1/advanced-resources/deploy/customizing-default-settings.md
@@ -187,8 +187,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.7.2/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.7.2/advanced-resources/deploy/customizing-default-settings.md
@@ -187,8 +187,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.7.3/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.7.3/advanced-resources/deploy/customizing-default-settings.md
@@ -187,8 +187,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.7.4/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.7.4/advanced-resources/deploy/customizing-default-settings.md
@@ -187,8 +187,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.8.0/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.8.0/advanced-resources/deploy/customizing-default-settings.md
@@ -187,8 +187,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.8.1/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.8.1/advanced-resources/deploy/customizing-default-settings.md
@@ -188,8 +188,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.8.2/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.8.2/advanced-resources/deploy/customizing-default-settings.md
@@ -188,8 +188,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.8.3/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.8.3/advanced-resources/deploy/customizing-default-settings.md
@@ -188,8 +188,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.9.0/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.9.0/advanced-resources/deploy/customizing-default-settings.md
@@ -189,8 +189,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.9.1/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.9.1/advanced-resources/deploy/customizing-default-settings.md
@@ -189,8 +189,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.9.2/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.9.2/advanced-resources/deploy/customizing-default-settings.md
@@ -189,8 +189,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/docs/archives/1.9.3/advanced-resources/deploy/customizing-default-settings.md
+++ b/content/docs/archives/1.9.3/advanced-resources/deploy/customizing-default-settings.md
@@ -189,8 +189,9 @@ From the project view in Rancher, go to **Apps && Marketplace > Longhorn > Upgra
 ### Using Kubectl
 
 If you prefer to use the command line to update the setting, you could use `kubectl`.
+To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.
 ```shell
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
 
 ### Using Helm

--- a/content/kb/troubleshooting-default-settings-do-not-persist.md
+++ b/content/kb/troubleshooting-default-settings-do-not-persist.md
@@ -30,5 +30,7 @@ We recommend using the Longhorn UI to change Longhorn setting on the existing cl
 
 You can also use the `kubectl`, but please be aware **this will bypass Longhorn backend validation**.
 ```
-kubectl edit settings <SETTING-NAME> -n longhorn-system
+kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
 ```
+
+To avoid collisions with other CRDs that also define a `settings` resource, use the fully qualified name `settings.longhorn.io` (or the short name `lhs`).


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/11690

#### What this PR does / why we need it:
#1198 updated the current Longhorn docs to use `settings.longhorn.io` (or `lhs`) instead of bare `settings`, so `kubectl` does not hit CRD name collisions.

This PR finishes the remaining spots that still used the short name:

- KB: `content/kb/troubleshooting-default-settings-do-not-persist.md`
- Archives: `content/docs/archives/1.2.3` … `1.9.3` `customizing-default-settings.md` (40 files)

Older archives that never documented `kubectl edit settings` are left alone. Current docs and 1.10+ archives were already fixed.

#### Special notes for your reviewer:
Sample change:

```diff
- kubectl edit settings <SETTING-NAME> -n longhorn-system
+ kubectl edit settings.longhorn.io <SETTING-NAME> -n longhorn-system
```

Plus the same collision note used in the current docs:

> To avoid collisions with other CRDs, do not use the simple `settings`. Instead, use `settings.longhorn.io` or `lhs`.