### PR TITLE
docs: update the minimum Kubernetes version requirement to v1.34

### DIFF
--- a/content/docs/1.11.3/deploy/install/_index.md
+++ b/content/docs/1.11.3/deploy/install/_index.md
@@ -42,7 +42,7 @@ For information on deploying Longhorn on specific nodes and rejecting general wo
 Each node in the Kubernetes cluster where Longhorn is installed must fulfill the following requirements:
 
 -  A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
--  Kubernetes >= v1.25
+-  Kubernetes >= v1.34
 -  `open-iscsi` is installed, and the `iscsid` daemon is running on all the nodes. This is necessary, since Longhorn relies on `iscsiadm` on the host to provide persistent volumes to Kubernetes. For help installing `open-iscsi`, refer to [Installing open-iscsi](#installing-open-iscsi).
 -  RWX support requires that each node has a NFSv4 client installed.
     - For installing a NFSv4 client, refer to [Installing NFSv4 Client](#installing-nfsv4-client).
@@ -84,7 +84,7 @@ Client Version: version.Info{Major:"1", Minor:"26", GitVersion:"v1.26.10", GitCo
 Server Version: version.Info{Major:"1", Minor:"26", GitVersion:"v1.26.10+k3s2", GitCommit:"cb5cb5557f34e240e38c68a8c4ca2506c68b1d86", GitTreeState:"clean", BuildDate:"2023-11-08T03:21:46Z", GoVersion:"go1.20.10", Compiler:"gc", Platform:"linux/amd64"}
 ```
 
-The `Server Version` should be >= v1.25.
+The `Server Version` should be >= v1.34.
 
 ### Pod Security Policy
 

--- a/content/docs/1.11.3/important-notes/_index.md
+++ b/content/docs/1.11.3/important-notes/_index.md
@@ -80,7 +80,7 @@ For more details, see [#13424](https://github.com/longhorn/longhorn/issues/13424
 
 ### Kubernetes Version Requirement
 
-Due to the upgrade of the CSI external snapshotter to v8.2.0, all clusters must be running Kubernetes v1.25 or later before you can upgrade to Longhorn v1.8.0 or a newer version.
+Due to the upgrade of the CSI external snapshotter to v8.2.0, all clusters must be running Kubernetes v1.34 or later before you can upgrade to Longhorn v1.8.0 or a newer version.
 
 ### Upgrade Check Events
 

--- a/content/docs/1.11.4/deploy/install/_index.md
+++ b/content/docs/1.11.4/deploy/install/_index.md
@@ -42,7 +42,7 @@ For information on deploying Longhorn on specific nodes and rejecting general wo
 Each node in the Kubernetes cluster where Longhorn is installed must fulfill the following requirements:
 
 -  A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
--  Kubernetes >= v1.25
+-  Kubernetes >= v1.34
 -  `open-iscsi` is installed, and the `iscsid` daemon is running on all the nodes. This is necessary, since Longhorn relies on `iscsiadm` on the host to provide persistent volumes to Kubernetes. For help installing `open-iscsi`, refer to [Installing open-iscsi](#installing-open-iscsi).
 -  RWX support requires that each node has a NFSv4 client installed.
     - For installing a NFSv4 client, refer to [Installing NFSv4 Client](#installing-nfsv4-client).
@@ -84,7 +84,7 @@ Client Version: version.Info{Major:"1", Minor:"26", GitVersion:"v1.26.10", GitCo
 Server Version: version.Info{Major:"1", Minor:"26", GitVersion:"v1.26.10+k3s2", GitCommit:"cb5cb5557f34e240e38c68a8c4ca2506c68b1d86", GitTreeState:"clean", BuildDate:"2023-11-08T03:21:46Z", GoVersion:"go1.20.10", Compiler:"gc", Platform:"linux/amd64"}
 ```
 
-The `Server Version` should be >= v1.25.
+The `Server Version` should be >= v1.34.
 
 ### Pod Security Policy
 

--- a/content/docs/1.11.4/important-notes/_index.md
+++ b/content/docs/1.11.4/important-notes/_index.md
@@ -80,7 +80,7 @@ For more details, see [#12807](https://github.com/longhorn/longhorn/issues/12807
 
 ### Kubernetes Version Requirement
 
-Due to the upgrade of the CSI external snapshotter to v8.2.0, all clusters must be running Kubernetes v1.25 or later before you can upgrade to Longhorn v1.8.0 or a newer version.
+Due to the upgrade of the CSI external snapshotter to v8.2.0, all clusters must be running Kubernetes v1.34 or later before you can upgrade to Longhorn v1.8.0 or a newer version.
 
 ### Upgrade Check Events
 

--- a/content/docs/1.12.1/deploy/install/_index.md
+++ b/content/docs/1.12.1/deploy/install/_index.md
@@ -56,7 +56,7 @@ Unless otherwise noted, the requirements in this section apply to both the V1 an
 Each node in the Kubernetes cluster where Longhorn is installed must fulfill the following requirements:
 
 -  A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
--  Kubernetes >= v1.25
+-  Kubernetes >= v1.34
 -  RWX support requires that each node has a NFSv4 client installed.
     - For installing a NFSv4 client, refer to [Install NFSv4 client](#install-nfsv4-client).
 - `bash`, `curl`, `findmnt`, `grep`, `awk`, `blkid`, `lsblk` must be installed.
@@ -81,7 +81,7 @@ You must perform additional setups before using Longhorn with certain operating 
 
 ### Kubernetes Version
 
-Longhorn requires Kubernetes >= v1.25.
+Longhorn requires Kubernetes >= v1.34.
 
 Use the following command to verify your cluster version:
 

--- a/content/docs/1.12.1/important-notes/_index.md
+++ b/content/docs/1.12.1/important-notes/_index.md
@@ -165,7 +165,7 @@ For more information, see [Issue #9205](https://github.com/longhorn/longhorn/iss
 
 ### Kubernetes Version Requirement
 
-Because the CSI external snapshotter is upgraded to v8.2.0, all clusters must be running Kubernetes v1.25 or later before upgrading to Longhorn v{{< current-version >}}.
+Because the CSI external snapshotter is upgraded to v8.2.0, all clusters must be running Kubernetes v1.34 or later before upgrading to Longhorn v{{< current-version >}}.
 
 ### Manual Checks Before Upgrade
 

--- a/content/docs/1.13.0/deploy/install/_index.md
+++ b/content/docs/1.13.0/deploy/install/_index.md
@@ -56,7 +56,7 @@ Unless otherwise noted, the requirements in this section apply to both the V1 an
 Each node in the Kubernetes cluster where Longhorn is installed must fulfill the following requirements:
 
 -  A container runtime compatible with Kubernetes (Docker v1.13+, containerd v1.3.7+, etc.)
--  Kubernetes >= v1.25
+-  Kubernetes >= v1.34
 -  RWX support requires that each node has a NFSv4 client installed.
     - For installing a NFSv4 client, refer to [Install NFSv4 client](#install-nfsv4-client).
 - `bash`, `curl`, `findmnt`, `grep`, `awk`, `blkid`, `lsblk` must be installed.
@@ -81,7 +81,7 @@ You must perform additional setups before using Longhorn with certain operating 
 
 ### Kubernetes Version
 
-Longhorn requires Kubernetes >= v1.25.
+Longhorn requires Kubernetes >= v1.34.
 
 Use the following command to verify your cluster version:
 

--- a/content/docs/1.13.0/important-notes/_index.md
+++ b/content/docs/1.13.0/important-notes/_index.md
@@ -165,7 +165,7 @@ For more information, see [Issue #9205](https://github.com/longhorn/longhorn/iss
 
 ### Kubernetes Version Requirement
 
-Because the CSI external snapshotter is upgraded to v8.2.0, all clusters must be running Kubernetes v1.25 or later before upgrading to Longhorn v{{< current-version >}}.
+Because the CSI external snapshotter is upgraded to v8.2.0, all clusters must be running Kubernetes v1.34 or later before upgrading to Longhorn v{{< current-version >}}.
 
 ### Manual Checks Before Upgrade
 


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13576

#### What this PR does / why we need it:

Update the minimum Kubernetes version requirement to v1.34 for Longhorn v1.11.3+, v1.12.1+ and v1.13.0+ because of the csi external provisioner v6.3.0+.


#### Special notes for your reviewer:

#### Additional documentation or context
