### PR TITLE
docs(1.13.0): add longhornctl check replica to command overview

### DIFF
--- a/content/docs/1.13.0/advanced-resources/longhornctl/_index.md
+++ b/content/docs/1.13.0/advanced-resources/longhornctl/_index.md
@@ -15,7 +15,7 @@ The `longhornctl` tool is a CLI interface to Longhorn operations. It interacts w
   * `longhornctl trim volume`: Reclaim unused storage space within a Longhorn volume.
 * **Troubleshooting:**
   * `longhornctl check preflight`: Identifies potential issues before usage.
-  * `longhornctl check replica`: Check the integrity of the snapshot chains in the Longhorn replica data directories (v1 data engine) and identify broken snapshot chains.
+  * `longhornctl check replica`: Check the integrity of the snapshot chains in the Longhorn replica data directories (V1 Data Engine) and identify broken snapshot chains.
   * `longhornctl get replica`: Retrieve details about Longhorn replicas on the host.
 
 ## Usage

--- a/content/docs/1.13.0/advanced-resources/longhornctl/_index.md
+++ b/content/docs/1.13.0/advanced-resources/longhornctl/_index.md
@@ -15,6 +15,7 @@ The `longhornctl` tool is a CLI interface to Longhorn operations. It interacts w
   * `longhornctl trim volume`: Reclaim unused storage space within a Longhorn volume.
 * **Troubleshooting:**
   * `longhornctl check preflight`: Identifies potential issues before usage.
+  * `longhornctl check replica`: Check the integrity of the snapshot chains in the Longhorn replica data directories (v1 data engine) and identify broken snapshot chains.
   * `longhornctl get replica`: Retrieve details about Longhorn replicas on the host.
 
 ## Usage


### PR DESCRIPTION
Issue longhorn/longhorn#9102

Adds the new `longhornctl check replica` command (implemented in longhorn/cli#561, milestone v1.13.0) to the Troubleshooting list on the longhornctl command overview page for the 1.13.0 docs.

The detailed command reference (`docs/longhornctl_check_replica.md`) is generated in the longhorn/cli repository as part of the implementation PR, following the same pattern as the other commands, so this page only needs the overview entry.
