### PR TITLE
fix(docs): correct ublk kernel v6.17 limitation description in v1.12.0, v1.12.1, v1.13.0 docs

### DIFF
--- a/content/docs/1.12.0/advanced-resources/v2-data-engine/ublk-frontend-support.md
+++ b/content/docs/1.12.0/advanced-resources/v2-data-engine/ublk-frontend-support.md
@@ -3,7 +3,7 @@ title: UBLK Frontend Support (Experimental)
 weight: 50
 ---
 
-> **Note**: This feature is an Experimental feature and is only functional on Linux kernels below v6.17. On kernel v6.17.0 and above, UBLK fails due to upstream UBLK API changes that cause `EINVAL` errors when starting UBLK devices. This issue is being tracked in [GitHub Issue #11977](https://github.com/longhorn/longhorn/issues/11977).
+> **Note**: This feature is an Experimental. The UBLK frontend works on all supported Linux kernels but may cause a kernel panic with kernel v6.17. For more information, see [GitHub Issue #11977](https://github.com/longhorn/longhorn/issues/11977) and [GitHub Issue #13509](https://github.com/longhorn/longhorn/issues/13509).
 
 Starting with v1.9.0, Longhorn supports the UBLK frontend for v2 data engine volumes.
 This feature exposes v2 data engine volumes as a block device by using [UBLK SPDK framework](https://spdk.io/doc/ublk.html).

--- a/content/docs/1.12.0/important-notes/_index.md
+++ b/content/docs/1.12.0/important-notes/_index.md
@@ -80,9 +80,10 @@ On ARM64 systems, V2 volumes may experience stuck I/O when SPDK is configured wi
 
 #### UBLK Frontend Kernel Limitation
 
-The UBLK frontend for V2 Data Engine volumes is experimental and only functional on Linux kernels below v6.17. On kernel v6.17.0 and above, UBLK fails due to upstream UBLK API changes that cause `EINVAL` errors when starting UBLK devices.
+This feature is an Experimental. The UBLK frontend works on all supported Linux kernels but may cause a kernel panic with kernel v6.17.
 
-For more information, see [Issue #11977](https://github.com/longhorn/longhorn/issues/11977) and [UBLK Frontend Support](../advanced-resources/v2-data-engine/ublk-frontend-support).
+For more information, see [GitHub Issue #11977](https://github.com/longhorn/longhorn/issues/11977) and [GitHub Issue #13509](https://github.com/longhorn/longhorn/issues/13509).
+
 
 #### Longhorn System Upgrade
 

--- a/content/docs/1.12.1/advanced-resources/v2-data-engine/ublk-frontend-support.md
+++ b/content/docs/1.12.1/advanced-resources/v2-data-engine/ublk-frontend-support.md
@@ -3,7 +3,7 @@ title: UBLK Frontend Support (Experimental)
 weight: 50
 ---
 
-> **Note**: This feature is an Experimental feature and is only functional on Linux kernels below v6.17. On kernel v6.17.0 and above, UBLK fails due to upstream UBLK API changes that cause `EINVAL` errors when starting UBLK devices. This issue is being tracked in [GitHub Issue #11977](https://github.com/longhorn/longhorn/issues/11977).
+> **Note**: This feature is an Experimental. The UBLK frontend works on all supported Linux kernels but may cause a kernel panic with kernel v6.17. For more information, see [GitHub Issue #11977](https://github.com/longhorn/longhorn/issues/11977) and [GitHub Issue #13509](https://github.com/longhorn/longhorn/issues/13509).
 
 Starting with v1.9.0, Longhorn supports the UBLK frontend for v2 data engine volumes.
 This feature exposes v2 data engine volumes as a block device by using [UBLK SPDK framework](https://spdk.io/doc/ublk.html).

--- a/content/docs/1.12.1/important-notes/_index.md
+++ b/content/docs/1.12.1/important-notes/_index.md
@@ -98,7 +98,7 @@ On ARM64 systems, V2 volumes may experience stuck I/O when SPDK is configured wi
 
 #### UBLK Frontend Kernel Limitation
 
-The UBLK frontend for V2 Data Engine volumes is experimental and only functional on Linux kernels below v6.17. On kernel v6.17.0 and above, UBLK fails due to upstream UBLK API changes that cause `EINVAL` errors when starting UBLK devices.
+This feature is an Experimental. The UBLK frontend works on all supported Linux kernels but may cause a kernel panic with kernel v6.17. For more information, see [GitHub Issue #11977](https://github.com/longhorn/longhorn/issues/11977) and [GitHub Issue #13509](https://github.com/longhorn/longhorn/issues/13509).
 
 For more information, see [Issue #11977](https://github.com/longhorn/longhorn/issues/11977) and [UBLK Frontend Support](../advanced-resources/v2-data-engine/ublk-frontend-support).
 

--- a/content/docs/1.13.0/important-notes/_index.md
+++ b/content/docs/1.13.0/important-notes/_index.md
@@ -95,9 +95,9 @@ On ARM64 systems, V2 volumes may experience stuck I/O when SPDK is configured wi
 
 #### UBLK Frontend Kernel Limitation
 
-The UBLK frontend for V2 Data Engine volumes is experimental and only functional on Linux kernels below v6.17. On kernel v6.17.0 and above, UBLK fails due to upstream UBLK API changes that cause `EINVAL` errors when starting UBLK devices.
+This feature is an Experimental. The UBLK frontend works on all supported Linux kernels but may cause a kernel panic with kernel v6.17. 
 
-For more information, see [Issue #11977](https://github.com/longhorn/longhorn/issues/11977) and [UBLK Frontend Support](../advanced-resources/v2-data-engine/ublk-frontend-support).
+For more information, see [GitHub Issue #11977](https://github.com/longhorn/longhorn/issues/11977) and [GitHub Issue #13509](https://github.com/longhorn/longhorn/issues/13509).
 
 #### Longhorn System Upgrade
 


### PR DESCRIPTION

Issue [#11977](https://github.com/longhorn/longhorn/issues/11977)

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
