### PR TITLE
docs(1.13.0): check-preflight extends check for iommu support

### DIFF
--- a/content/docs/1.13.0/deploy/install/_index.md
+++ b/content/docs/1.13.0/deploy/install/_index.md
@@ -196,8 +196,8 @@ The command used to install a NFSv4 client differs depending on the Linux distri
 
 You can also use the [Longhorn Command Line Tool](#longhorn-command-line-tool) to install `nfs-client` automatically.
 
-> **Notice:**  
-> These steps only verify that the kernel supports NFSv4, v4.1, or v4.2.  
+> **Notice:**
+> These steps only verify that the kernel supports NFSv4, v4.1, or v4.2.
 > To verify the NFS version in use, run `mount | grep nfs` or `nfsstat -m` to confirm the mounted version. Using the correct NFS version is required for backup and RWX volume features in Longhorn.
 
 ### Install Cryptsetup and LUKS
@@ -520,6 +520,7 @@ This command validates, among other things:
 
 - CPU instruction requirements
 - HugePages availability
+- IOMMU support
 - SPDK-related kernel modules
 - Base Longhorn dependencies such as `open-iscsi` and NFS support
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/12076

#### What this PR does / why we need it:
Updates the following indicating how `check preflight` also reports about IOMMU support now:
- `Note` in interrup-mode-support
- list in `Check Prerequisites`

#### Special notes for your reviewer:

#### Additional documentation or context
