### PR TITLE
docs: add NVMe BDF I/O queue constraints for v2 data engine

### DIFF
--- a/content/docs/1.11.0/v2-data-engine/features/configurable-cpu-cores.md
+++ b/content/docs/1.11.0/v2-data-engine/features/configurable-cpu-cores.md
@@ -14,6 +14,14 @@ The CPU mask is a **hexadecimal (hex) representation of a binary bitmask**, wher
 - A bit set to **1** means the core is enabled for the data engine.
 - A bit set to **0** means the core is skipped.
 
+> **Important: NVMe BDF Block Devices and I/O Queues**
+> 
+> When using `nvme` disk driver for a block-type disk, SPDK unbinds the kernel NVMe driver and takes over the physical controller directly. SPDK allocates one I/O queue pair per allocated CPU core. 
+> 
+> Because of this, **the physical NVMe device's I/O queue count must be strictly greater than the number of SPDK CPU cores configured via the CPU mask**. 
+> 
+> If the CPU mask allocates as many or more cores than the available I/O queues on the physical device (for example, allocating 2 cores to an EBS NVMe volume that only provides 2 I/O queues), SPDK will exhaust the queues. This leads to incomplete I/O processing and causes volume I/O to hang indefinitely.
+
 ### How to Calculate the Mask
 
 To determine the correct hex string, visualize your CPU cores as a sequence of bits from right to left:

--- a/content/docs/1.11.1/v2-data-engine/features/configurable-cpu-cores.md
+++ b/content/docs/1.11.1/v2-data-engine/features/configurable-cpu-cores.md
@@ -14,6 +14,14 @@ The CPU mask is a **hexadecimal (hex) representation of a binary bitmask**, wher
 - A bit set to **1** means the core is enabled for the data engine.
 - A bit set to **0** means the core is skipped.
 
+> **Important: NVMe BDF Block Devices and I/O Queues**
+> 
+> When using `nvme` disk driver for a block-type disk, SPDK unbinds the kernel NVMe driver and takes over the physical controller directly. SPDK allocates one I/O queue pair per allocated CPU core. 
+> 
+> Because of this, **the physical NVMe device's I/O queue count must be strictly greater than the number of SPDK CPU cores configured via the CPU mask**. 
+> 
+> If the CPU mask allocates as many or more cores than the available I/O queues on the physical device (for example, allocating 2 cores to an EBS NVMe volume that only provides 2 I/O queues), SPDK will exhaust the queues. This leads to incomplete I/O processing and causes volume I/O to hang indefinitely.
+
 ### How to Calculate the Mask
 
 To determine the correct hex string, visualize your CPU cores as a sequence of bits from right to left:

--- a/content/docs/1.11.2/v2-data-engine/features/configurable-cpu-cores.md
+++ b/content/docs/1.11.2/v2-data-engine/features/configurable-cpu-cores.md
@@ -14,6 +14,14 @@ The CPU mask is a **hexadecimal (hex) representation of a binary bitmask**, wher
 - A bit set to **1** means the core is enabled for the data engine.
 - A bit set to **0** means the core is skipped.
 
+> **Important: NVMe BDF Block Devices and I/O Queues**
+> 
+> When using `nvme` disk driver for a block-type disk, SPDK unbinds the kernel NVMe driver and takes over the physical controller directly. SPDK allocates one I/O queue pair per allocated CPU core. 
+> 
+> Because of this, **the physical NVMe device's I/O queue count must be strictly greater than the number of SPDK CPU cores configured via the CPU mask**. 
+> 
+> If the CPU mask allocates as many or more cores than the available I/O queues on the physical device (for example, allocating 2 cores to an EBS NVMe volume that only provides 2 I/O queues), SPDK will exhaust the queues. This leads to incomplete I/O processing and causes volume I/O to hang indefinitely.
+
 ### How to Calculate the Mask
 
 To determine the correct hex string, visualize your CPU cores as a sequence of bits from right to left:

--- a/content/docs/1.11.3/v2-data-engine/features/configurable-cpu-cores.md
+++ b/content/docs/1.11.3/v2-data-engine/features/configurable-cpu-cores.md
@@ -14,6 +14,14 @@ The CPU mask is a **hexadecimal (hex) representation of a binary bitmask**, wher
 - A bit set to **1** means the core is enabled for the data engine.
 - A bit set to **0** means the core is skipped.
 
+> **Important: NVMe BDF Block Devices and I/O Queues**
+> 
+> When using `nvme` disk driver for a block-type disk, SPDK unbinds the kernel NVMe driver and takes over the physical controller directly. SPDK allocates one I/O queue pair per allocated CPU core. 
+> 
+> Because of this, **the physical NVMe device's I/O queue count must be strictly greater than the number of SPDK CPU cores configured via the CPU mask**. 
+> 
+> If the CPU mask allocates as many or more cores than the available I/O queues on the physical device (for example, allocating 2 cores to an EBS NVMe volume that only provides 2 I/O queues), SPDK will exhaust the queues. This leads to incomplete I/O processing and causes volume I/O to hang indefinitely.
+
 ### How to Calculate the Mask
 
 To determine the correct hex string, visualize your CPU cores as a sequence of bits from right to left:

--- a/content/docs/1.11.4/v2-data-engine/features/configurable-cpu-cores.md
+++ b/content/docs/1.11.4/v2-data-engine/features/configurable-cpu-cores.md
@@ -14,6 +14,14 @@ The CPU mask is a **hexadecimal (hex) representation of a binary bitmask**, wher
 - A bit set to **1** means the core is enabled for the data engine.
 - A bit set to **0** means the core is skipped.
 
+> **Important: NVMe BDF Block Devices and I/O Queues**
+> 
+> When using `nvme` disk driver for a block-type disk, SPDK unbinds the kernel NVMe driver and takes over the physical controller directly. SPDK allocates one I/O queue pair per allocated CPU core. 
+> 
+> Because of this, **the physical NVMe device's I/O queue count must be strictly greater than the number of SPDK CPU cores configured via the CPU mask**. 
+> 
+> If the CPU mask allocates as many or more cores than the available I/O queues on the physical device (for example, allocating 2 cores to an EBS NVMe volume that only provides 2 I/O queues), SPDK will exhaust the queues. This leads to incomplete I/O processing and causes volume I/O to hang indefinitely.
+
 ### How to Calculate the Mask
 
 To determine the correct hex string, visualize your CPU cores as a sequence of bits from right to left:

--- a/content/docs/1.12.0/advanced-resources/v2-data-engine/configurable-cpu-cores.md
+++ b/content/docs/1.12.0/advanced-resources/v2-data-engine/configurable-cpu-cores.md
@@ -14,6 +14,14 @@ The CPU mask is a **hexadecimal (hex) representation of a binary bitmask**, wher
 - A bit set to **1** means the core is enabled for the data engine.
 - A bit set to **0** means the core is skipped.
 
+> **Important: NVMe BDF Block Devices and I/O Queues**
+> 
+> When using `nvme` disk driver for a block-type disk, SPDK unbinds the kernel NVMe driver and takes over the physical controller directly. SPDK allocates one I/O queue pair per allocated CPU core. 
+> 
+> Because of this, **the physical NVMe device's I/O queue count must be strictly greater than the number of SPDK CPU cores configured via the CPU mask**. 
+> 
+> If the CPU mask allocates as many or more cores than the available I/O queues on the physical device (for example, allocating 2 cores to an EBS NVMe volume that only provides 2 I/O queues), SPDK will exhaust the queues. This leads to incomplete I/O processing and causes volume I/O to hang indefinitely.
+
 ### How to Calculate the Mask
 
 To determine the correct hex string, visualize your CPU cores as a sequence of bits from right to left:

--- a/content/docs/1.12.1/advanced-resources/v2-data-engine/configurable-cpu-cores.md
+++ b/content/docs/1.12.1/advanced-resources/v2-data-engine/configurable-cpu-cores.md
@@ -14,6 +14,14 @@ The CPU mask is a **hexadecimal (hex) representation of a binary bitmask**, wher
 - A bit set to **1** means the core is enabled for the data engine.
 - A bit set to **0** means the core is skipped.
 
+> **Important: NVMe BDF Block Devices and I/O Queues**
+> 
+> When using `nvme` disk driver for a block-type disk, SPDK unbinds the kernel NVMe driver and takes over the physical controller directly. SPDK allocates one I/O queue pair per allocated CPU core. 
+> 
+> Because of this, **the physical NVMe device's I/O queue count must be strictly greater than the number of SPDK CPU cores configured via the CPU mask**. 
+> 
+> If the CPU mask allocates as many or more cores than the available I/O queues on the physical device (for example, allocating 2 cores to an EBS NVMe volume that only provides 2 I/O queues), SPDK will exhaust the queues. This leads to incomplete I/O processing and causes volume I/O to hang indefinitely.
+
 ### How to Calculate the Mask
 
 To determine the correct hex string, visualize your CPU cores as a sequence of bits from right to left:

--- a/content/docs/1.12.2/advanced-resources/v2-data-engine/configurable-cpu-cores.md
+++ b/content/docs/1.12.2/advanced-resources/v2-data-engine/configurable-cpu-cores.md
@@ -14,6 +14,14 @@ The CPU mask is a **hexadecimal (hex) representation of a binary bitmask**, wher
 - A bit set to **1** means the core is enabled for the data engine.
 - A bit set to **0** means the core is skipped.
 
+> **Important: NVMe BDF Block Devices and I/O Queues**
+> 
+> When using `nvme` disk driver for a block-type disk, SPDK unbinds the kernel NVMe driver and takes over the physical controller directly. SPDK allocates one I/O queue pair per allocated CPU core. 
+> 
+> Because of this, **the physical NVMe device's I/O queue count must be strictly greater than the number of SPDK CPU cores configured via the CPU mask**. 
+> 
+> If the CPU mask allocates as many or more cores than the available I/O queues on the physical device (for example, allocating 2 cores to an EBS NVMe volume that only provides 2 I/O queues), SPDK will exhaust the queues. This leads to incomplete I/O processing and causes volume I/O to hang indefinitely.
+
 ### How to Calculate the Mask
 
 To determine the correct hex string, visualize your CPU cores as a sequence of bits from right to left:

--- a/content/docs/1.13.0/advanced-resources/v2-data-engine/configurable-cpu-cores.md
+++ b/content/docs/1.13.0/advanced-resources/v2-data-engine/configurable-cpu-cores.md
@@ -14,13 +14,13 @@ The CPU mask is a **hexadecimal (hex) representation of a binary bitmask**, wher
 - A bit set to **1** means the core is enabled for the data engine.
 - A bit set to **0** means the core is skipped.
 
-### Important: NVMe BDF Block Devices and I/O Queues
-
-When using BDF (PCIe) paths (for example, `0000:00:1f.0`) for NVMe block devices in the V2 data engine, SPDK unbinds the kernel NVMe driver and takes over the physical controller directly. SPDK allocates one I/O queue pair per allocated CPU core. 
-
-Because of this, **the physical NVMe device's I/O queue count must be strictly greater than the number of SPDK CPU cores configured via the CPU mask**. 
-
-If the CPU mask allocates as many or more cores than the available I/O queues on the physical device (for example, allocating 2 cores to an EBS NVMe volume that only provides 2 I/O queues), SPDK will exhaust the queues. This leads to incomplete I/O processing and causes volume I/O to hang indefinitely. 
+> **Important: NVMe BDF Block Devices and I/O Queues**
+> 
+> When using `nvme` disk driver for a block-type disk, SPDK unbinds the kernel NVMe driver and takes over the physical controller directly. SPDK allocates one I/O queue pair per allocated CPU core. 
+> 
+> Because of this, **the physical NVMe device's I/O queue count must be strictly greater than the number of SPDK CPU cores configured via the CPU mask**. 
+> 
+> If the CPU mask allocates as many or more cores than the available I/O queues on the physical device (for example, allocating 2 cores to an EBS NVMe volume that only provides 2 I/O queues), SPDK will exhaust the queues. This leads to incomplete I/O processing and causes volume I/O to hang indefinitely.
 
 ### How to Calculate the Mask
 

--- a/content/docs/1.13.0/advanced-resources/v2-data-engine/configurable-cpu-cores.md
+++ b/content/docs/1.13.0/advanced-resources/v2-data-engine/configurable-cpu-cores.md
@@ -14,6 +14,14 @@ The CPU mask is a **hexadecimal (hex) representation of a binary bitmask**, wher
 - A bit set to **1** means the core is enabled for the data engine.
 - A bit set to **0** means the core is skipped.
 
+### Important: NVMe BDF Block Devices and I/O Queues
+
+When using BDF (PCIe) paths (for example, `0000:00:1f.0`) for NVMe block devices in the V2 data engine, SPDK unbinds the kernel NVMe driver and takes over the physical controller directly. SPDK allocates one I/O queue pair per allocated CPU core. 
+
+Because of this, **the physical NVMe device's I/O queue count must be strictly greater than the number of SPDK CPU cores configured via the CPU mask**. 
+
+If the CPU mask allocates as many or more cores than the available I/O queues on the physical device (for example, allocating 2 cores to an EBS NVMe volume that only provides 2 I/O queues), SPDK will exhaust the queues. This leads to incomplete I/O processing and causes volume I/O to hang indefinitely. 
+
 ### How to Calculate the Mask
 
 To determine the correct hex string, visualize your CPU cores as a sequence of bits from right to left:


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

[Issue #13939](https://github.com/longhorn/longhorn/issues/13939)

#### What this PR does / why we need it:

Updates the `configurable-cpu-cores.md` documentation to highlight a critical hardware constraint for the v2 data engine. 

#### Special notes for your reviewer:

N/A

#### Additional documentation or context:

N/A
