### PR TITLE
docs(1.13.0): add Longhorn Global Manager

### DIFF
--- a/content/docs/1.13.0/advanced-resources/deploy/node-selector.md
+++ b/content/docs/1.13.0/advanced-resources/deploy/node-selector.md
@@ -26,6 +26,9 @@ You need to set node selector for both types of components. See more details bel
         longhornManager:
           nodeSelector:
             label-key1: "label-value1"
+        longhornGlobalManager:
+          nodeSelector:
+            label-key1: "label-value1"
         longhornDriver:
           nodeSelector:
             label-key1: "label-value1"
@@ -33,9 +36,9 @@ You need to set node selector for both types of components. See more details bel
           nodeSelector:
             label-key1: "label-value1"
       ```
-   * If you install Longhorn by using `kubectl` to apply [the deployment YAML](https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml), you need to modify the node selector section for Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer.
+   * If you install Longhorn by using `kubectl` to apply [the deployment YAML](https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml), you need to modify the node selector section for Longhorn Manager, Longhorn Global Manager, Longhorn UI, and Longhorn Driver Deployer.
     Then apply the YAMl files.
-   * If you install Longhorn using Helm, you can change the Helm values for `global.nodeSelector`, `longhornManager.nodeSelector`, `longhornUI.nodeSelector`, `longhornDriver.nodeSelector` in the `values.yaml` file before installing the chart.
+   * If you install Longhorn using Helm, you can change the Helm values for `global.nodeSelector`, `longhornManager.nodeSelector`, `longhornGlobalManager.nodeSelector`, `longhornUI.nodeSelector`, `longhornDriver.nodeSelector` in the `values.yaml` file before installing the chart.
 
 2. Set the node selector for system-managed components (for example, Instance Manager, Backing Image Manager, Share Manager, CSI Driver, and Engine Image).
 
@@ -71,6 +74,9 @@ You need to set node selector for both types of components. See more details bel
         longhornManager:
           nodeSelector:
             label-key1: "label-value1"
+        longhornGlobalManager:
+          nodeSelector:
+            label-key1: "label-value1"
         longhornDriver:
           nodeSelector:
             label-key1: "label-value1"
@@ -78,9 +84,9 @@ You need to set node selector for both types of components. See more details bel
           nodeSelector:
             label-key1: "label-value1"
         ```
-    * If you install Longhorn by using `kubectl` to apply [the deployment YAML](https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml), you need to modify the node selector section for Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer.
+    * If you install Longhorn by using `kubectl` to apply [the deployment YAML](https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml), you need to modify the node selector section for Longhorn Manager, Longhorn Global Manager, Longhorn UI, and Longhorn Driver Deployer.
       Then reapply the YAMl files.
-    * If you install Longhorn using Helm, you can change the Helm values for `global.nodeSelector`, `longhornManager.nodeSelector`, `longhornUI.nodeSelector`, `longhornDriverDeployer.nodeSelector` in the `values.yaml` file, and then run `helm upgrade` to upgrade to the new version of the chart.
+    * If you install Longhorn using Helm, you can change the Helm values for `global.nodeSelector`, `longhornManager.nodeSelector`, `longhornGlobalManager.nodeSelector`, `longhornUI.nodeSelector`, `longhornDriverDeployer.nodeSelector` in the `values.yaml` file, and then run `helm upgrade` to upgrade to the new version of the chart.
 
 3. Set the node selector for system-managed components (for example, Instance Manager, Backing Image Manager, Share Manager, CSI Driver, and Engine Image).
 

--- a/content/docs/1.13.0/advanced-resources/deploy/taint-toleration.md
+++ b/content/docs/1.13.0/advanced-resources/deploy/taint-toleration.md
@@ -32,6 +32,12 @@ You need to set tolerations for both types of components. See more details below
            operator: "Equal"
            value: "value"
            effect: "NoSchedule"
+       longhornGlobalManager:
+         tolerations:
+         - key: "key"
+           operator: "Equal"
+           value: "value"
+           effect: "NoSchedule"
        longhornDriver:
          tolerations:
          - key: "key"
@@ -45,9 +51,9 @@ You need to set tolerations for both types of components. See more details below
            value: "value"
            effect: "NoSchedule"
      ```
-   * If you install Longhorn by using `kubectl` to apply [the deployment YAML](https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml), you need to modify the taint tolerations section for Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer.
+   * If you install Longhorn by using `kubectl` to apply [the deployment YAML](https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml), you need to modify the taint tolerations section for Longhorn Manager, Longhorn Global Manager, Longhorn UI, and Longhorn Driver Deployer.
     Then apply the YAMl files.
-   * If you install Longhorn using Helm, you can change the Helm values for `global.tolerations`, `longhornManager.tolerations`, `longhornUI.tolerations`, `longhornDriver.tolerations` in the `values.yaml` file before installing the chart.
+   * If you install Longhorn using Helm, you can change the Helm values for `global.tolerations`, `longhornManager.tolerations`, `longhornGlobalManager.tolerations`, `longhornUI.tolerations`, `longhornDriver.tolerations` in the `values.yaml` file before installing the chart.
 
 2. Set taint tolerations for system-managed components (for example, Instance Manager, CSI Driver, and Engine images)
 
@@ -95,6 +101,12 @@ You need to set tolerations for both types of components. See more details below
            operator: "Equal"
            value: "value"
            effect: "NoSchedule"
+       longhornGlobalManager:
+         tolerations:
+         - key: "key"
+           operator: "Equal"
+           value: "value"
+           effect: "NoSchedule"
        longhornDriver:
          tolerations:
          - key: "key"
@@ -108,9 +120,9 @@ You need to set tolerations for both types of components. See more details below
            value: "value"
            effect: "NoSchedule"
      ```
-   * If you install Longhorn by using `kubectl` to apply [the deployment YAML](https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml), you need to modify the taint tolerations section for Longhorn Manager, Longhorn UI, and Longhorn Driver Deployer.
+   * If you install Longhorn by using `kubectl` to apply [the deployment YAML](https://raw.githubusercontent.com/longhorn/longhorn/v{{< current-version >}}/deploy/longhorn.yaml), you need to modify the taint tolerations section for Longhorn Manager, Longhorn Global Manager, Longhorn UI, and Longhorn Driver Deployer.
   Then reapply the YAMl files.
-   * If you install Longhorn using Helm, you can change the Helm values for `global.tolerations`, `longhornManager.tolerations`, `longhornUI.tolerations`, `longhornDriver.tolerations` in the `values.yaml` file, and then run `helm upgrade` to upgrade to the new version of the chart.
+   * If you install Longhorn using Helm, you can change the Helm values for `global.tolerations`, `longhornManager.tolerations`, `longhornGlobalManager.tolerations`, `longhornUI.tolerations`, `longhornDriver.tolerations` in the `values.yaml` file, and then run `helm upgrade` to upgrade to the new version of the chart.
 
 3. Set taint tolerations for system-managed components (for example, Instance Manager, Backing Image Manager, Share Manager, CSI Driver, and Engine Image).
 

--- a/content/docs/1.13.0/deploy/install/airgap.md
+++ b/content/docs/1.13.0/deploy/install/airgap.md
@@ -56,6 +56,7 @@ Longhorn can be installed in an air gapped environment by using a manifest file,
     * Add your secret name  `SECRET_NAME` to `imagePullSecrets.name` in the following resources
       * `longhorn-driver-deployer` Deployment
       * `longhorn-manager` DaemonSet
+      * `longhorn-global-manager` Deployment
       * `longhorn-ui` Deployment
 
       Example:

--- a/content/docs/1.13.0/deploy/install/install-with-helm.md
+++ b/content/docs/1.13.0/deploy/install/install-with-helm.md
@@ -50,6 +50,9 @@ In this section, you will learn how to install Longhorn with Helm.
     NAME                                                READY   STATUS    RESTARTS   AGE
     longhorn-ui-b7c844b49-w25g5                         1/1     Running   0          2m41s
     longhorn-manager-pzgsp                              1/1     Running   0          2m41s
+    longhorn-global-manager-5b7c9d8f4-2xk9p             1/1     Running   0          2m41s
+    longhorn-global-manager-5b7c9d8f4-8mq4z             1/1     Running   0          2m41s
+    longhorn-global-manager-5b7c9d8f4-t7wvn             1/1     Running   0          2m41s
     longhorn-driver-deployer-6bd59c9f76-lqczw           1/1     Running   0          2m41s
     longhorn-csi-plugin-mbwqz                           2/2     Running   0          100s
     csi-snapshotter-588457fcdf-22bqp                    1/1     Running   0          100s

--- a/content/docs/1.13.0/deploy/install/install-with-kubectl.md
+++ b/content/docs/1.13.0/deploy/install/install-with-kubectl.md
@@ -35,6 +35,9 @@ The initial settings for Longhorn can be customized by [editing the deployment c
     NAME                                                READY   STATUS    RESTARTS   AGE
     longhorn-ui-b7c844b49-w25g5                         1/1     Running   0          2m41s
     longhorn-manager-pzgsp                              1/1     Running   0          2m41s
+    longhorn-global-manager-5b7c9d8f4-2xk9p             1/1     Running   0          2m41s
+    longhorn-global-manager-5b7c9d8f4-8mq4z             1/1     Running   0          2m41s
+    longhorn-global-manager-5b7c9d8f4-t7wvn             1/1     Running   0          2m41s
     longhorn-driver-deployer-6bd59c9f76-lqczw           1/1     Running   0          2m41s
     longhorn-csi-plugin-mbwqz                           2/2     Running   0          100s
     csi-snapshotter-588457fcdf-22bqp                    1/1     Running   0          100s

--- a/content/docs/1.13.0/deploy/upgrade/longhorn-manager.md
+++ b/content/docs/1.13.0/deploy/upgrade/longhorn-manager.md
@@ -8,6 +8,9 @@ weight: 1
 We only support upgrading to v{{< current-version >}} from v1.11.x. For other versions, please upgrade to v1.11.x first.
 
 Engine live upgrade is supported from v1.11.x to v{{< current-version >}}.
+
+Starting with v1.13.0, upgrading Longhorn also creates the [Longhorn Global Manager](../../../terminology/#longhorn-global-manager) Deployment. Make sure that at least one of its Pods can be scheduled. For Helm installations, review the [Longhorn Global Manager settings](../../../references/helm-values/#longhorn-global-manager-settings); for manifest installations, review the Deployment's scheduling configuration in the deployment YAML.
+
 For airgap upgrades when Longhorn is installed as a Rancher app, you will need to modify the image names and remove the registry URL part.
 
 For example, the image `registry.example.com/longhorn/longhorn-manager:v{{< current-version >}}` is changed to `longhorn/longhorn-manager:v{{< current-version >}}` in Longhorn images section. For more information, see the air gap installation steps [here.](../../install/airgap/#using-a-rancher-app)

--- a/content/docs/1.13.0/references/helm-values.md
+++ b/content/docs/1.13.0/references/helm-values.md
@@ -117,6 +117,24 @@ Longhorn consists of user-deployed components (for example, Longhorn Manager, Lo
 | longhornManager.serviceAnnotations | object | `{}` | Annotation for the Longhorn Manager service. |
 | longhornManager.tolerations | list | `[]` | Toleration for Longhorn Manager on nodes allowed to run Longhorn Manager. |
 
+### Longhorn Global Manager Settings
+
+The following settings apply to the [Longhorn Global Manager](../../terminology/#longhorn-global-manager) Deployment.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| longhornGlobalManager.affinity | object | `{"podAntiAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"podAffinityTerm":{"labelSelector":{"matchExpressions":[{"key":"app","operator":"In","values":["longhorn-global-manager"]}]},"topologyKey":"kubernetes.io/hostname"},"weight":1}]}}` | Affinity for global manager pods. The default spreads replicas across nodes. |
+| longhornGlobalManager.annotations | object | `{}` | Annotations for global manager pods. |
+| longhornGlobalManager.nodeSelector | object | `{}` | Node selector for global manager pods. |
+| longhornGlobalManager.podDisruptionBudget | object | `{"enabled":false,"maxUnavailable":"","minAvailable":1}` | Pod Disruption Budget for the global manager. Keeps a minimum number of global manager pods available during voluntary disruptions such as node drains. Effective only when `longhornGlobalManager.replicas` is greater than 1. |
+| longhornGlobalManager.podDisruptionBudget.enabled | bool | `false` | Setting that allows you to enable the Pod Disruption Budget for the global manager. |
+| longhornGlobalManager.podDisruptionBudget.maxUnavailable | string | `""` | Maximum number or percentage of global manager pods that can be unavailable during a disruption. When set, it takes precedence over `longhornGlobalManager.podDisruptionBudget.minAvailable`. |
+| longhornGlobalManager.podDisruptionBudget.minAvailable | int | `1` | Minimum number or percentage of global manager pods that must remain available during a disruption. Mutually exclusive with `longhornGlobalManager.podDisruptionBudget.maxUnavailable`. |
+| longhornGlobalManager.priorityClass | string | `"longhorn-critical"` | PriorityClass for the global manager. |
+| longhornGlobalManager.replicas | int | `3` | Replica count for the global manager. One replica is the active leader; the others are warm standbys. |
+| longhornGlobalManager.resources | string | `nil` | Resource requests and limits for global manager pods. Memory scales with the cluster's Pod count (cluster-wide Pod informer cache). |
+| longhornGlobalManager.tolerations | list | `[]` | Node tolerations for global manager pods. |
+
 ### Longhorn Driver Settings
 
 Longhorn consists of user-deployed components (for example, Longhorn Manager, Longhorn Driver, and Longhorn UI) and system-managed components (for example, Instance Manager, Backing Image Manager, Share Manager, CSI Driver, and Engine Image). The following settings only apply to Longhorn Driver.

--- a/content/docs/1.13.0/references/networking.md
+++ b/content/docs/1.13.0/references/networking.md
@@ -43,6 +43,17 @@ To | Port | Protocol
 `External Backupstore` | User defined | TCP
 `Kubernetes API server` | `Kubernetes API server port` | TCP
 
+### Longhorn Global Manager
+#### Ingress:
+From | Port | Protocol
+--- | --- | ---
+`Kubelet (health probes)` | 9505 | TCP
+
+#### Egress:
+To | Port | Protocol
+--- | --- | ---
+`Kubernetes API server` | `Kubernetes API server port` | TCP
+
 ### UI
 #### ingress:
 Users defined

--- a/content/docs/1.13.0/terminology.md
+++ b/content/docs/1.13.0/terminology.md
@@ -135,7 +135,11 @@ A Longhorn Engine is a data plane component of Longhorn. It is a per-volume stor
 
 ### Longhorn Manager
 
-The Longhorn Manager is the control plane component of Longhorn. It runs as a Kubernetes DaemonSet. It is responsible for managing volumes, handling API requests, and orchestrating Longhorn Engines, Replicas, and other custom resources (CRs).
+The Longhorn Manager is a control plane component of Longhorn. It runs as a Kubernetes DaemonSet. It is responsible for managing volumes, handling API requests, and orchestrating Longhorn Engines, Replicas, and other custom resources (CRs).
+
+### Longhorn Global Manager
+
+The Longhorn Global Manager runs the Longhorn Manager's cluster-wide controllers as a Kubernetes Deployment. One elected leader runs these controllers.
 
 ### Longhorn Volume
 


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/13059

#### What this PR does / why we need it:
Documents the `longhorn-global-manager` Deployment introduced in v1.13.0: a terminology entry, the `longhornGlobalManager.*` Helm values, network policy ports, the expected pod list after install, air-gap `imagePullSecrets` targets, taint toleration / node selector examples, and an upgrade note about scheduling.

#### Special notes for your reviewer:
Applied to `content/docs/1.13.0` only, as the component is new in v1.13.0. The important-notes entry is left to the release notes owner.

#### Additional documentation or context
LEP: https://github.com/longhorn/longhorn/pull/13060
